### PR TITLE
Absolute timestamp for send

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ settings.json
 dist/**
 test**
 build**
+__**

--- a/docs/scripts/generate_autodoc.py
+++ b/docs/scripts/generate_autodoc.py
@@ -42,9 +42,9 @@ for item in inspect.getmembers(framework, lambda x: inspect.isclass(x) or inspec
             export_c += CLASS_TEMPLATE.format(class_name=item.__name__) + "\n"
 
 
-with open("autodoc_export_funct.rst", "w") as f:
+with open("__autodoc_export_funct.rst", "w") as f:
     f.write(export_f)
 
-with open("autodoc_export_class.rst", "w") as f:
+with open("__autodoc_export_class.rst", "w") as f:
     f.write(export_c)
     

--- a/docs/scripts/generate_error_codes.py
+++ b/docs/scripts/generate_error_codes.py
@@ -35,7 +35,7 @@ for exc in excs:
 export_e += ""
 
 
-with open("autodoc_export_exceptions.rst", "w") as f:
+with open("__autodoc_export_exceptions.rst", "w") as f:
     f.write(export_e)
 
 

--- a/src/framework/guild.py
+++ b/src/framework/guild.py
@@ -7,8 +7,6 @@ from    __future__ import annotations
 import asyncio
 from    contextlib import suppress
 from    typing import Any, Literal, Union, List, Optional
-
-from framework import misc
 from    .exceptions import *
 from    .tracing import *
 from    .const import *
@@ -16,6 +14,7 @@ from    .message import *
 from    . import client
 from    . import sql
 from    . import core
+from    . import misc
 import  _discord as discord
 import  time
 import  json

--- a/src/framework/message/voice_based.py
+++ b/src/framework/message/voice_based.py
@@ -7,6 +7,7 @@ from   ..tracing    import *
 from   ..const      import *
 from   ..exceptions import *
 from   typing       import Any, Dict, List, Iterable, Union
+from   datetime import timedelta
 from   ..           import client
 from   ..           import sql
 from   ..           import core
@@ -58,13 +59,13 @@ class VoiceMESSAGE(BaseMESSAGE):
             :caption: **Randomized** sending period between **5** seconds and **10** seconds.
             
             # Time between each send is somewhere between 5 seconds and 10 seconds.
-            framework.VoiceMESSAGE(start_period=None, end_period=10, data=framework.AUDIO("msg.mp3"), channels=[12345], start_now=True, volume=50)
+            framework.VoiceMESSAGE(start_period=None, end_period=10, data=framework.AUDIO("msg.mp3"), channels=[12345], start_in=timedelta(seconds=0), volume=50)
 
         .. code-block:: python
             :caption: **Fixed** sending period at **10** seconds
 
             # Time between each send is exactly 10 seconds.
-            framework.VoiceMESSAGE(start_period=None, end_period=10, data=framework.AUDIO("msg.mp3"), channels=[12345], start_now=True, volume=50)
+            framework.VoiceMESSAGE(start_period=None, end_period=10, data=framework.AUDIO("msg.mp3"), channels=[12345], start_in=timedelta(seconds=0), volume=50)
 
     data: AUDIO
         The data parameter is the actual data that will be sent using discord's API. The data types of this parameter can be:
@@ -74,7 +75,7 @@ class VoiceMESSAGE(BaseMESSAGE):
         Channels that it will be advertised into (Can be snowflake ID or channel objects from PyCord).
     volume: int         
         The volume (0-100%) at which to play the audio. Defaults to 50%. This was added in v2.0.0
-    start_now: bool
+    start_in: timedelta
         If True, then the framework will send the message as soon as it is run.      
     """
 
@@ -93,14 +94,14 @@ class VoiceMESSAGE(BaseMESSAGE):
     __logname__ = "VoiceMESSAGE"    # For sql._register_type
     __valid_data_types__ = {AUDIO}  # This is used in the BaseMESSAGE.initialize() to check if the passed data parameters are of correct type
 
-    def __init__(self, start_period: Union[float, None],
-                 end_period: float,
+    def __init__(self, start_period: Union[int, None],
+                 end_period: int,
                  data: AUDIO,
                  channels: Iterable[Union[int, discord.VoiceChannel]],
                  volume: int=50,
-                 start_now: bool = True):
+                 start_in: timedelta=timedelta(seconds=0)):
 
-        super().__init__(start_period, end_period, data, start_now)
+        super().__init__(start_period, end_period, data, start_in)
         self.volume = max(0, min(100, volume)) # Clamp the volume to 0-100 % 
         self.channels = list(set(channels))    # Auto remove duplicates
 
@@ -306,8 +307,8 @@ class VoiceMESSAGE(BaseMESSAGE):
         Other
             Raised from .initialize() method
         """
-        if "start_now" not in kwargs:
+        if "start_in" not in kwargs:
             # This parameter does not appear as attribute, manual setting necessary 
-            kwargs["start_now"] = True
+            kwargs["start_in"] = timedelta(seconds=0)
 
         await core._update(self, **kwargs) # No additional modifications are required

--- a/src/framework/misc.py
+++ b/src/framework/misc.py
@@ -5,6 +5,7 @@
 
 from typing import Coroutine, Callable, Any, Optional
 from asyncio import Semaphore
+import functools as fts
 
 
 ###############################
@@ -64,6 +65,7 @@ def _async_safe(semaphore: str, amount: Optional[int]=1) -> Callable:
         Decorator that returns a method wrapper Coroutine that utilizes a
         asyncio semaphore to assure safe asynchronous operations.
         """
+        @fts.wraps(coroutine)
         async def wrapper(self, *args, **kwargs):
             sem: Semaphore = getattr(self, semaphore)
             for i in range(amount):

--- a/src/framework/misc.py
+++ b/src/framework/misc.py
@@ -27,8 +27,6 @@ def _write_attr_once(obj: Any, name: str, value: Any):
     value: Any
         The value to change the attribute with.
     """
-
-    # TODO: Test if it works
     if not hasattr(obj, name): # Write only if forced, or if not forced, then the attribute must not exist
         setattr(obj, name, value)
 
@@ -37,7 +35,6 @@ def _write_attr_once(obj: Any, name: str, value: Any):
 ###########################
 # Decorators
 ###########################
-# TODO: Change Lock to semaphore, add parameter that dictates how many to take
 def _async_safe(semaphore: str, amount: Optional[int]=1) -> Callable:
     """
     Function that returns a safety decorator, which uses the :strong:`semaphore` parameter

--- a/src/framework/sql.py
+++ b/src/framework/sql.py
@@ -17,12 +17,12 @@ from  sqlalchemy.orm import sessionmaker, Session
 from  sqlalchemy.ext.declarative import declarative_base
 from  pytds import ClosedConnectionError
 
-from framework import misc
 from  .tracing import *
 from  .timing import *
 from  .const import *
 from  .exceptions import *
 from  . import core
+from  . import misc
 import sqlalchemy as sqa
 import json
 import copy

--- a/src/framework/timing.py
+++ b/src/framework/timing.py
@@ -36,10 +36,13 @@ def timeit(num: int):
         return _timeit(tmp)
     return _timeit
 
-
+# Deprecated
 class TIMER:
     """
     Used in MESSAGE objects as a send timer.
+    
+    .. deprecated:: v2.1
+        Since v2.1, absolute timestamp is used.
     """
     __slots__ = (
         "running",
@@ -72,3 +75,5 @@ class TIMER:
         Resets the timer.
         """
         self.running = False
+
+    


### PR DESCRIPTION
Changes
----------------
Instead of relying on a timer to send messages (relative time), absolute timestamp is now used for sending messages
to prevent time slippage due to missed timer resets.
#126 