### PR TITLE
Refactoring, item rearangement inside GUI

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -38,6 +38,10 @@ GUI:
 
   - Template backups for each structured objects.
   - Rearanging of list items inside GUI listboxes
+  - Connection timeout to a remote core is now 10 minutes for large datasets.
+  - Dictionary editing - GUI nows allows to edit / view dictionary types (JSON). This could eg. be used
+    to view SQL log's content which is saved to the database into JSON format.
+
 
 v2.8.4
 =================

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -32,6 +32,13 @@ Glossary
 Releases
 ----------------------
 
+v2.9
+=================
+GUI:
+
+  - Template backups for each structured objects.
+  - Rearanging of list items inside GUI listboxes
+
 v2.8.4
 =================
 - Fixed web browser waiting time being too little when searching invite links

--- a/main.py
+++ b/main.py
@@ -1,4 +1,0 @@
-import daf_gui
-
-
-daf_gui.run()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,4 @@
+import daf_gui
+
+
+daf_gui.run()

--- a/src/daf/__init__.py
+++ b/src/daf/__init__.py
@@ -19,4 +19,4 @@ if DOCUMENTATION_MODE:
     from .misc import *
 
 
-VERSION = "2.8.4"
+VERSION = "2.9"

--- a/src/daf/__init__.py
+++ b/src/daf/__init__.py
@@ -19,4 +19,4 @@ if DOCUMENTATION_MODE:
     from .misc import *
 
 
-VERSION = "2.9"
+VERSION = "2.9.0"

--- a/src/daf_gui/__init__.py
+++ b/src/daf_gui/__init__.py
@@ -1,1 +1,4 @@
+"""
+Graphical interface for Discord Advertisement Framework.
+"""
 from .main import run

--- a/src/daf_gui/connector.py
+++ b/src/daf_gui/connector.py
@@ -172,6 +172,8 @@ class RemoteConnectionCLIENT(AbstractConnectionCLIENT):
     verify_ssl: Optional[bool]
         Defaults to True. If True, connection will be refused when the certificate does not match the host name.
     """
+    TIMEOUT = 10 * 60  # * seconds / minute
+
     def __init__(
         self,
         host: str,
@@ -201,7 +203,7 @@ class RemoteConnectionCLIENT(AbstractConnectionCLIENT):
             additional_kwargs["ssl"] = False
 
         trace(f"Requesting {route} with {method}.", TraceLEVELS.DEBUG)
-        async with getattr(self.session, method)(route, json={"parameters": kwargs}, **additional_kwargs) as response:
+        async with getattr(self.session, method)(route, json={"parameters": kwargs}, timeout=self.TIMEOUT, **additional_kwargs) as response:
             if response.status != 200:
                 raise web.HTTPException(reason=response.reason)
 

--- a/src/daf_gui/extra.py
+++ b/src/daf_gui/extra.py
@@ -109,7 +109,7 @@ def setup_additional_live_update(w: ttk.Button, frame):
             old = frame.old_gui_data
             values = {
                 k: convert_to_objects(v)
-                for k, v in frame._read_gui_values().items()
+                for k, v in frame.get_gui_data().items()
                 if not isinstance(v, str) or v != ''
             }
             connector = get_connection()

--- a/src/daf_gui/extra.py
+++ b/src/daf_gui/extra.py
@@ -99,14 +99,14 @@ def setup_additional_widget_file_chooser_logger(w: ttk.Button, frame):
 def setup_additional_live_update(w: ttk.Button, frame):
     # Don't have a bound object instance
     if (
-        (oi := frame.old_object_info) is None or
+        (oi := frame.old_gui_data) is None or
         oi.real_object is None
     ):
         return
 
     def _callback(*args):
         async def update():
-            old = frame.old_object_info
+            old = frame.old_gui_data
             values = {
                 k: convert_to_objects(v)
                 for k, v in frame._read_gui_values().items()
@@ -125,7 +125,7 @@ def setup_additional_live_update(w: ttk.Button, frame):
 def setup_additional_live_refresh(w: ttk.Button, frame):
     # Don't have a bound object instance
     if (
-        (oi := frame.old_object_info) is None or
+        (oi := frame.old_gui_data) is None or
         oi.real_object is None
     ):
         return
@@ -136,9 +136,9 @@ def setup_additional_live_refresh(w: ttk.Button, frame):
             connection = get_connection()
             # Need to do this on all previous frames, otherwise we would have wrong data
             for frame_ in reversed(opened_frames):
-                old_object_info = frame_.old_object_info
-                if not isinstance(old_object_info, list) and hasattr(old_object_info.real_object, "_daf_id"):
-                    real = await connection.refresh(old_object_info.real_object)  # Get refresh object from DAF
+                old_gui_data = frame_.old_gui_data
+                if not isinstance(old_gui_data, list) and hasattr(old_gui_data.real_object, "_daf_id"):
+                    real = await connection.refresh(old_gui_data.real_object)  # Get refresh object from DAF
                     frame_._update_old_object(convert_to_object_info(real, True))
                     frame_.load()
 

--- a/src/daf_gui/extra.py
+++ b/src/daf_gui/extra.py
@@ -139,10 +139,9 @@ def setup_additional_live_refresh(w: ttk.Button, frame):
                 old_gui_data = frame_.old_gui_data
                 if not isinstance(old_gui_data, list) and hasattr(old_gui_data.real_object, "_daf_id"):
                     real = await connection.refresh(old_gui_data.real_object)  # Get refresh object from DAF
-                    frame_._update_old_object(convert_to_object_info(real, True))
-                    frame_.load()
+                    frame_.load(convert_to_object_info(real, True))
 
-                frame_.save_gui_values()
+                frame_.remember_gui_data()
 
         async_execute(refresh(), parent_window=frame.origin_window)
 

--- a/src/daf_gui/main.py
+++ b/src/daf_gui/main.py
@@ -340,18 +340,18 @@ class Application():
         list_live_objects.pack(fill=tk.BOTH, expand=True)
         self.list_live_objects = list_live_objects
         # The default bind is removal from list and not from actual daf.
-        list_live_objects.listbox.unbind("<BackSpace>")
-        list_live_objects.listbox.unbind("<Delete>")
-        list_live_objects.listbox.bind("<BackSpace>", lambda e: remove_account())
-        list_live_objects.listbox.bind("<Delete>", lambda e: remove_account())
+        list_live_objects.unbind("<BackSpace>")
+        list_live_objects.unbind("<Delete>")
+        list_live_objects.bind("<BackSpace>", lambda e: remove_account())
+        list_live_objects.bind("<Delete>", lambda e: remove_account())
 
     def init_output_tab(self):
         self.tab_output = ttk.Frame(self.tabman_mf)
         self.tabman_mf.add(self.tab_output, text="Output")
         text_output = ListBoxScrolled(self.tab_output)
-        text_output.listbox.unbind("<Control-c>")
-        text_output.listbox.unbind("<BackSpace>")
-        text_output.listbox.unbind("<Delete>")
+        text_output.unbind("<Control-c>")
+        text_output.unbind("<BackSpace>")
+        text_output.unbind("<Delete>")
         text_output.pack(fill=tk.BOTH, expand=True)
 
         class STDIOOutput:
@@ -754,7 +754,7 @@ daf.run(
             if accounts is not None:
                 accounts = convert_from_json(accounts)
                 self.lb_accounts.clear()
-                self.lb_accounts.listbox.insert(tk.END, *accounts)
+                self.lb_accounts.insert(tk.END, *accounts)
 
             # Load loggers
             logging_data = json_data.get("loggers")

--- a/src/daf_gui/main.py
+++ b/src/daf_gui/main.py
@@ -177,6 +177,7 @@ class Application():
         # Accounts list. Defined here since it's needed below
         self.lb_accounts = ListBoxScrolled(frame_tab_account)
 
+        @gui_except
         @gui_confirm_action
         def import_accounts():
             "Imports account from live view"
@@ -192,6 +193,7 @@ class Application():
                 self.lb_accounts.clear()
                 self.lb_accounts.insert(tk.END, *values)
 
+            gui_daf_assert_running()
             async_execute(import_accounts_async(), parent_window=self.win_main)
 
         menu_bnt = ttk.Menubutton(

--- a/src/daf_gui/main.py
+++ b/src/daf_gui/main.py
@@ -312,7 +312,7 @@ class Application():
                 self.open_object_edit_window(
                     daf.ACCOUNT,
                     list_live_objects,
-                    old=object_
+                    old_data=object_
                 )
             else:
                 tkdiag.Messagebox.show_error("Select one item!", "Empty list!")
@@ -604,7 +604,7 @@ class Application():
             self.open_object_edit_window(
                 type_,
                 listbox,
-                old=object_,
+                old_data=object_,
                 check_parameters=False,
                 allow_save=False
             )
@@ -615,7 +615,7 @@ class Application():
         selection = self.combo_logging_mgr.current()
         if selection >= 0:
             object_: ObjectInfo = self.combo_logging_mgr.get()
-            self.open_object_edit_window(object_.class_, self.combo_logging_mgr, old=object_)
+            self.open_object_edit_window(object_.class_, self.combo_logging_mgr, old_data=object_)
         else:
             tkdiag.Messagebox.show_error("Select atleast one item!", "Empty list!")
 
@@ -623,7 +623,7 @@ class Application():
         selection = self.lb_accounts.curselection()
         if len(selection):
             object_: ObjectInfo = self.lb_accounts.get()[selection[0]]
-            self.open_object_edit_window(daf.ACCOUNT, self.lb_accounts, old=object_)
+            self.open_object_edit_window(daf.ACCOUNT, self.lb_accounts, old_data=object_)
         else:
             tkdiag.Messagebox.show_error("Select atleast one item!", "Empty list!")
 
@@ -866,7 +866,3 @@ def run():
     loop.run_until_complete(update_task())
     loop.run_until_complete(async_stop())
     asyncio.set_event_loop(None)
-
-
-if __name__ == "__main__":
-    run()

--- a/src/daf_gui/object.py
+++ b/src/daf_gui/object.py
@@ -158,7 +158,6 @@ class ObjectEditWindow(ttk.Toplevel):
 
 
 class NewObjectFrame(ttk.Frame):
-
     """
     Frame for inside the :class:`ObjectEditWindow` that allows object definition.
 
@@ -427,8 +426,9 @@ class NewObjectFrame(ttk.Frame):
 
     def init_iterable(self):
         w = ListBoxScrolled(self.frame_main, height=20)
+        dpi_5 = dpi_scaled(5)
         self._map[None] = (w, [list])
-        frame_edit_remove = ttk.Frame(self.frame_main)
+        frame_edit_remove = ttk.Frame(self.frame_main, padding=(dpi_5, 0))
         frame_edit_remove.pack(side="right")
         if self.allow_save:
             menubtn = ttk.Menubutton(frame_edit_remove, text="Add object")
@@ -437,6 +437,12 @@ class NewObjectFrame(ttk.Frame):
             menubtn.pack()
             ttk.Button(frame_edit_remove, text="Remove", command=w.delete_selected).pack(fill=tk.X)
             ttk.Button(frame_edit_remove, text="Edit", command=self.listbox_edit_selected(w)).pack(fill=tk.X)
+
+            frame_up_down = ttk.Frame(frame_edit_remove)
+            frame_up_down.pack(fill=tk.X, expand=True, pady=dpi_5)
+            ttk.Button(frame_up_down, text="Up", command=lambda: w.move_selection(-1)).pack(side="left", fill=tk.X, expand=True)
+            ttk.Button(frame_up_down, text="Down", command=lambda: w.move_selection(1)).pack(side="left", fill=tk.X, expand=True)
+
             args = get_args(self.class_)
             args = self.convert_types(args)
             if get_origin(args[0]) is Union:
@@ -704,7 +710,7 @@ class NewObjectFrame(ttk.Frame):
 
                 ret_widget.delete(ind)
 
-        self.return_widget.insert(tk.END, new)
+        self.return_widget.insert(ind, new)
         if isinstance(self.return_widget, ComboBoxObjects):
             self.return_widget.current(self.return_widget["values"].index(new))
 

--- a/src/daf_gui/object.py
+++ b/src/daf_gui/object.py
@@ -1,7 +1,7 @@
 """
 Contains definitions for automatic object definition windows and frames.
 """
-from typing import get_args, get_origin, Iterable, Union, Literal
+from typing import get_args, get_origin, Iterable, Union, Literal, Dict, Tuple
 
 from collections.abc import Iterable as ABCIterable
 from contextlib import suppress
@@ -33,7 +33,6 @@ __all__ = (
     "ListBoxScrolled",
     "ComboBoxObjects",
     "ObjectEditWindow",
-    "NewObjectFrame",
     "ComboBoxText",
     "ComboEditFrame",
 )
@@ -80,6 +79,19 @@ class ObjectEditWindow(ttk.Toplevel):
     """
     Top level window for creating and editing new objects.
     """
+
+    # Map used to map types to specific class.
+    # If type is not in this map, structured object will be assumed.
+    TYPE_INIT_MAP = {
+        str: None,
+        float: None,
+        int: None,
+        list: None,
+        Iterable: None,
+        ABCIterable: None,
+        tuple: None
+    }
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._closed = False
@@ -109,22 +121,28 @@ class ObjectEditWindow(ttk.Toplevel):
         self.attributes("-topmost", var.get())
 
         # Window initialization
-        NewObjectFrame.set_origin_window(self)
+        NewObjectFrameStruct.set_origin_window(self)
         self.protocol("WM_DELETE_WINDOW", self.close_object_edit_frame)
 
     @property
     def closed(self) -> bool:
         return self._closed
 
-    def open_object_edit_frame(self, *args, **kwargs):
+    def open_object_edit_frame(self, class_, *args, **kwargs):
         """
         Opens new frame for defining an object.
+        Parameters are the same as for NewObjectFrameBase.
         """
         prev_frame = None
         if len(self.opened_frames):
-            prev_frame = self.opened_frames[-1]          
+            prev_frame = self.opened_frames[-1]
 
-        self.opened_frames.append(frame := NewObjectFrame(parent=self.frame_main, *args, **kwargs))
+        class_origin = get_origin(class_)
+        if class_origin is None:
+            class_origin = class_
+
+        frame_class = self.TYPE_INIT_MAP.get(class_origin, NewObjectFrameStruct)
+        self.opened_frames.append(frame := frame_class(class_, *args, **kwargs, parent=self.frame_main))
         frame.pack(fill=tk.BOTH, expand=True)
         frame.update_window_title()
         if prev_frame is not None:
@@ -157,342 +175,48 @@ class ObjectEditWindow(ttk.Toplevel):
         self.geometry(f"{self.winfo_width()}x{self.winfo_reqheight()}")
 
 
-class NewObjectFrame(ttk.Frame):
+class NewObjectFrameBase(ttk.Frame):
     """
-    Frame for inside the :class:`ObjectEditWindow` that allows object definition.
+    Base Frame for inside the :class:`ObjectEditWindow` that allows object definition.
 
     Parameters
     -------------
     class_: Any
         The class we are defining for.
-    return_widget: ComboBoxObjects | ListBoxScrolled
+    return_widget: Any
         The widget to insert the ObjectInfo into after saving.
     parent: TopLevel
         The parent window.
-    old: ObjectInfo
-        The old ObjectInfo object to edit.
+    old: Any
+        The old gui data.
     check_parameters: bool
         Check parameters (by creating the real object) upon saving.
         This is ignored if editing a function instead of a class.
     allow_save: bool
         If False, will open in read-only mode.
-    additional_values: Dict[str, Any]
-        A mapping of additional values to be inserted into corresponding field.
     """
     origin_window: ObjectEditWindow = None
 
-    TYPE_INIT_MAP = {
-        str: "init_str",
-        float: "init_int_float",
-        int: "init_int_float",
-        list: "init_iterable",
-        Iterable: "init_iterable",
-        ABCIterable: "init_iterable",
-        tuple: "init_iterable"
-    }
-
     def __init__(
         self,
-        class_,
-        return_widget: Union[ComboBoxObjects, ListBoxScrolled],
+        class_: Any,
+        return_widget: Any,
         parent = None,
-        old: ObjectInfo = None,
+        old: Any = None,
         check_parameters: bool = True,
         allow_save = True,
-        additional_values: dict = {},
     ):
         self.class_ = class_
-        self.return_widget = return_widget
-        self._map = {}
+        self.return_widget: Union[ComboBoxObjects, ListBoxObjects] = return_widget
         self._original_gui_data = {}
         self.parent = parent
-        self.old_object_info = old  # Edit requested
+        self.old_gui_data = old  # Edit requested
         self.check_parameters = check_parameters  # At save time
         self.allow_save = allow_save  # Allow save or not allow (eg. viewing SQL data)
-        self.method_exec_frame = None  # Frame within current frame for executing methods
-        self.additional_values = additional_values
 
         super().__init__(master=parent)
-        annotations = self.get_annotations(class_)
-        if (
-            class_ not in self.TYPE_INIT_MAP and get_origin(class_) not in self.TYPE_INIT_MAP and
-            (not annotations or old is not None and not isinstance(old, ObjectInfo))
-        ):
-            tkdiag.Messagebox.show_error("This object cannot be edited.", "Load error", parent=self.origin_window)
-            self.origin_window.after_idle(self._cleanup)  # Can not clean the object before it has been added to list
-            return
-
         self.init_toolbar_frame(class_)
-        self.init_main_frame(class_, annotations)
-        self.init_method_frame(class_)
-
-        if old is not None:  # Edit
-            self.load()
-
-        self.save_gui_values()
-
-    def init_main_frame(self, class_, annotations: dict) -> bool:
-        frame_main = ttk.Frame(self)
-        frame_main.pack(expand=True, fill=tk.BOTH)
-        self.frame_main = frame_main
-
-        method = self.TYPE_INIT_MAP.get(class_)
-        if method is None:
-            method = self.TYPE_INIT_MAP.get(get_origin(class_))  # Try with origin
-
-        if method is not None:
-            getattr(self, method)()
-        else:
-            self.init_structured(annotations)
-
-    def init_toolbar_frame(self, class_):
-        frame_toolbar = ttk.Frame(self)
-        self.frame_toolbar = frame_toolbar
-
-        # Help button
-        package = class_.__module__.split(".", 1)[0]
-        help_url = HELP_URLS.get(package)
-        if help_url is not None:
-            def cmd():
-                webbrowser.open(help_url.format(self.get_cls_name(class_)))
-
-            ttk.Button(frame_toolbar, text="Help", command=cmd).pack(side="left")
-
-        # Additional widgets
-        add_widgets = ADDITIONAL_WIDGETS.get(class_)
-        if add_widgets is not None:
-            for add_widg in add_widgets:
-                setup_cmd = add_widg.setup_cmd
-                add_widg = add_widg.widget_class(frame_toolbar, *add_widg.args, **add_widg.kwargs)
-                setup_cmd(add_widg, self)
-
-        frame_toolbar.pack(fill=tk.X)
-
-    def init_method_frame(self, class_):
-        # Method execution
-        if (
-            self.old_object_info is None or
-            # getattr since class_ can also be non ObjectInfo
-            getattr(self.old_object_info, "real_object", None) is None or
-            (available_methods := EXECUTABLE_METHODS.get(class_)) is None
-        ):
-            return
-
-        def execute_method():
-            async def runner():
-                method = frame_execute_method.combo.get()
-                if not isinstance(method, ObjectInfo):  # String typed in that doesn't match any names
-                    tkdiag.Messagebox.show_error("No method selected!", "Selection error")
-                    return
-
-                method_param = convert_to_objects(method.data, skip_real_conversion=True)
-                connection = get_connection()
-                # Call the method though the connection manager
-                await connection.execute_method(
-                    self.old_object_info.real_object,
-                    method.class_.__name__,
-                    **method_param,
-                )
-
-            async_execute(runner(), parent_window=self.origin_window)
-
-        dpi_5, dpi_10 = dpi_scaled(5), dpi_scaled(10)
-        frame_method = ttk.LabelFrame(self, text="Method execution", padding=(dpi_5, dpi_10), bootstyle=ttk.INFO)
-        ttk.Button(frame_method, text="Execute", command=execute_method).pack(side="left")
-        combo_values = []
-        for unbound_meth in available_methods:
-            combo_values.append(ObjectInfo(unbound_meth, {}))
-
-        def new_object_frame_with_values(class_, widget, *args, **kwargs):
-            """
-            Middleware method for opening a new object frame, that fills in additional
-            values for the specific method (class_) we are editing.
-            """
-            extra_values = ADDITIONAL_PARAMETER_VALUES.get(class_, {}).copy()
-            for k, v in extra_values.items():
-                extra_values[k] = v(self.old_object_info)
-
-            return self.new_object_frame(class_, widget, *args, **kwargs, additional_values=extra_values)
-
-        frame_execute_method = ComboEditFrame(
-            new_object_frame_with_values,
-            combo_values,
-            master=frame_method
-        )
-        frame_execute_method.pack(side="right", fill=tk.X, expand=True)
-        frame_method.pack(fill=tk.X)
-
-    def init_structured(self, annotations: dict):
-        dpi_5 = dpi_scaled(5)
-
-        # Template
-        @gui_except(parent=self)
-        def save_template():
-            filename = tkfile.asksaveasfilename(filetypes=[("JSON", "*.json")], parent=self)
-            if filename == "":
-                return
-
-            json_data = convert_to_json(self._gui_to_object(ignore_checks=True))
-
-            if not filename.endswith(".json"):
-                filename += ".json"
-
-            with open(filename, "w", encoding="utf-8") as file:
-                json.dump(json_data, file, indent=2)
-
-            tkdiag.Messagebox.show_info(f"Saved to {filename}", "Finished", self)
-
-        @gui_except(parent=self)
-        def load_template():
-            filename = tkfile.askopenfilename(filetypes=[("JSON", "*.json")], parent=self)
-            if filename == "":
-                return
-
-            with open(filename, "r", encoding="utf-8") as file:
-                json_data: dict = json.load(file)
-                object_info = convert_from_json(json_data)
-                # Get class_ attribute if we have the ObjectInfo type, if not just compare the actual type
-                if object_info.class_ is not self.class_:
-                    raise TypeError(
-                        f"The selected template is not a {self.class_.__name__} template.\n"
-                        f"The requested template is for type: {object_info.class_.__name__}!"
-                    )
-
-                self.load(object_info)
-                
-        bnt_menu_template = ttk.Menubutton(self.frame_toolbar, text="Template")
-        menu = ttk.Menu(bnt_menu_template)
-        menu.add_command(label="Load template", command=load_template)
-        menu.add_command(label="Save template", command=save_template)
-        bnt_menu_template.configure(menu=menu)
-        bnt_menu_template.pack(side="left")
-
-        def fill_values(k: str, entry_types: list, menu: ttk.Menu, combo: ComboBoxObjects):
-            "Fill ComboBox values based on types in ``entry_types`` and create New <object_type> buttons"
-            last_list_type = None
-            for entry_type in entry_types:
-                if get_origin(entry_type) is Literal:
-                    combo["values"] = get_args(entry_type)
-                elif entry_type is bool:
-                    combo.insert(tk.END, True)
-                    combo.insert(tk.END, False)
-                elif issubclass_noexcept(entry_type, Enum):
-                    combo["values"] = [en for en in entry_type]
-                elif entry_type is type(None):
-                    if bool not in entry_types:
-                        combo.insert(tk.END, None)
-                else:  # Type not supported, try other types
-                    if get_origin(entry_type) in {list, tuple, set, Iterable, ABCIterable}:
-                        last_list_type = entry_type
-
-                    if self.allow_save:
-                        menu.add_command(
-                            label=f"New {self.get_cls_name(entry_type)}",
-                            command=self._lambda(self.new_object_frame, entry_type, combo)
-                        )
-
-            # Additional values to be inserted into ComboBox
-            for value in self.additional_values.get(k, []):
-                combo.insert(tk.END, value)
-
-            # The class of last list like type. Needed when "Edit selected" is used
-            # since we don't know what type it was
-            return last_list_type
-
-        for (k, v) in annotations.items():
-            # Init widgets
-            entry_types = self.convert_types(v)
-            frame_annotated = ttk.Frame(self.frame_main)
-            frame_annotated.pack(fill=tk.BOTH, expand=True)
-            ttk.Label(frame_annotated, text=k, width=15).pack(side="left")
-
-            bnt_menu = ttk.Menubutton(frame_annotated)
-            menu = tk.Menu(bnt_menu)
-            bnt_menu.configure(menu=menu)
-            bnt_menu.pack(side="right")
-
-            w = combo = ComboBoxObjects(frame_annotated)
-            combo.pack(fill=tk.X, side="right", expand=True, padx=dpi_5, pady=dpi_5)
-
-            # Fill values
-            last_list_type = fill_values(k, entry_types, menu, combo)
-
-            # Edit / view command button
-            menu.add_command(
-                label=f"{'Edit' if self.allow_save else 'View'} selected",
-                command=self.combo_edit_selected(w, last_list_type)
-            )
-            self._map[k] = (w, entry_types)
-
-    def init_iterable(self):
-        w = ListBoxScrolled(self.frame_main, height=20)
-        dpi_5 = dpi_scaled(5)
-        self._map[None] = (w, [list])
-        frame_edit_remove = ttk.Frame(self.frame_main, padding=(dpi_5, 0))
-        frame_edit_remove.pack(side="right")
-        if self.allow_save:
-            menubtn = ttk.Menubutton(frame_edit_remove, text="Add object")
-            menu = tk.Menu(menubtn)
-            menubtn.configure(menu=menu)
-            menubtn.pack()
-            ttk.Button(frame_edit_remove, text="Remove", command=w.delete_selected).pack(fill=tk.X)
-            ttk.Button(frame_edit_remove, text="Edit", command=self.listbox_edit_selected(w)).pack(fill=tk.X)
-
-            frame_up_down = ttk.Frame(frame_edit_remove)
-            frame_up_down.pack(fill=tk.X, expand=True, pady=dpi_5)
-            ttk.Button(frame_up_down, text="Up", command=lambda: w.move_selection(-1)).pack(side="left", fill=tk.X, expand=True)
-            ttk.Button(frame_up_down, text="Down", command=lambda: w.move_selection(1)).pack(side="left", fill=tk.X, expand=True)
-
-            args = get_args(self.class_)
-            args = self.convert_types(args)
-            if get_origin(args[0]) is Union:
-                args = get_args(args[0])
-
-            for arg in args:
-                menu.add_command(label=self.get_cls_name(arg), command=self._lambda(self.new_object_frame, arg, w))
-        else:
-            ttk.Button(frame_edit_remove, text="View", command=self.listbox_edit_selected(w)).pack(fill=tk.X)
-
-        w.pack(side="left", fill=tk.BOTH, expand=True)
-
-    def init_int_float(self):
-        w = ttk.Spinbox(self.frame_main, from_=-9999, to=9999)
-        w.pack(fill=tk.X)
-        self._map[None] = (w, [self.class_])
-
-    def init_str(self):
-        w = Text(self.frame_main, undo=True, maxundo=TEXT_MAX_UNDO)
-        w.pack(fill=tk.BOTH, expand=True)
-        self._map[None] = (w, [self.class_])
-
-    def _read_gui_values(self) -> dict:
-        """
-        Returns dictionary who's keys are the class parameters and keys
-        are the actual values.
-        """
-        values = {}
-        for attr, (widget, types_) in self._map.items():
-            value = widget.get()
-            if isinstance(value, (list, tuple, set)):  # Copy lists else the values would change in the original state
-                value = copy.copy(value)
-
-            values[attr] = value
-
-        return values
-
-    def save_gui_values(self):
-        """
-        Saves the original GUI values for change check at save.
-        """
-        self._original_gui_data = self._read_gui_values()
-
-    @property
-    def modified(self) -> bool:
-        """
-        Returns True if the GUI values have been modified.
-        """
-        current_values = self._read_gui_values()
-        return current_values != self._original_gui_data
+        self.init_main_frame()
 
     @staticmethod
     def get_cls_name(cls):
@@ -504,21 +228,11 @@ class NewObjectFrame(ttk.Frame):
             return cls
 
     @staticmethod
-    def get_annotations(class_):
-        annotations = {}
-        with suppress(AttributeError):
-            if inspect.isclass(class_):
-                annotations = class_.__init__.__annotations__
-            else:
-                annotations = class_.__annotations__
+    def _lambda(method, *args, **kwargs):
+        def _():
+            return method(*args, **kwargs)
 
-        additional_annotations = ADDITIONAL_ANNOTATIONS.get(class_, {})
-        annotations = {**annotations, **additional_annotations}
-
-        if "return" in annotations:
-            del annotations["return"]
-
-        return annotations
+        return _
 
     @classmethod
     def set_origin_window(cls, window: ObjectEditWindow):
@@ -555,8 +269,87 @@ class NewObjectFrame(ttk.Frame):
         # Remove wrapped classes (eg. wrapped by decorator)
         return remove_wrapped(types_in + subtypes)
 
+    def init_main_frame(self):
+        frame_main = ttk.Frame(self)
+        frame_main.pack(expand=True, fill=tk.BOTH)
+        self.frame_main = frame_main
+
+    def init_toolbar_frame(self, class_):
+        frame_toolbar = ttk.Frame(self)
+        self.frame_toolbar = frame_toolbar
+
+        # Help button
+        package = class_.__module__.split(".", 1)[0]
+        help_url = HELP_URLS.get(package)
+        if help_url is not None:
+            def cmd():
+                webbrowser.open(help_url.format(self.get_cls_name(class_)))
+
+            ttk.Button(frame_toolbar, text="Help", command=cmd).pack(side="left")
+
+        # Additional widgets
+        add_widgets = ADDITIONAL_WIDGETS.get(class_)
+        if add_widgets is not None:
+            for add_widg in add_widgets:
+                setup_cmd = add_widg.setup_cmd
+                add_widg = add_widg.widget_class(frame_toolbar, *add_widg.args, **add_widg.kwargs)
+                setup_cmd(add_widg, self)
+
+        frame_toolbar.pack(fill=tk.X)
+
+    # TODO: turn into subclasses
+    def __init_iterable(self):
+        w = ListBoxScrolled(self.frame_main, height=20)
+        dpi_5 = dpi_scaled(5)
+        self._map[None] = (w, [list])
+        frame_edit_remove = ttk.Frame(self.frame_main, padding=(dpi_5, 0))
+        frame_edit_remove.pack(side="right")
+        if self.allow_save:
+            menubtn = ttk.Menubutton(frame_edit_remove, text="Add object")
+            menu = tk.Menu(menubtn)
+            menubtn.configure(menu=menu)
+            menubtn.pack()
+            ttk.Button(frame_edit_remove, text="Remove", command=w.delete_selected).pack(fill=tk.X)
+            ttk.Button(frame_edit_remove, text="Edit", command=self.listbox_edit_selected(w)).pack(fill=tk.X)
+
+            frame_up_down = ttk.Frame(frame_edit_remove)
+            frame_up_down.pack(fill=tk.X, expand=True, pady=dpi_5)
+            ttk.Button(frame_up_down, text="Up", command=lambda: w.move_selection(-1)).pack(side="left", fill=tk.X, expand=True)
+            ttk.Button(frame_up_down, text="Down", command=lambda: w.move_selection(1)).pack(side="left", fill=tk.X, expand=True)
+
+            args = get_args(self.class_)
+            args = self.convert_types(args)
+            if get_origin(args[0]) is Union:
+                args = get_args(args[0])
+
+            for arg in args:
+                menu.add_command(label=self.get_cls_name(arg), command=self._lambda(self.new_object_frame, arg, w))
+        else:
+            ttk.Button(frame_edit_remove, text="View", command=self.listbox_edit_selected(w)).pack(fill=tk.X)
+
+        w.pack(side="left", fill=tk.BOTH, expand=True)
+
+    def __init_int_float(self):
+        w = ttk.Spinbox(self.frame_main, from_=-9999, to=9999)
+        w.pack(fill=tk.X)
+        self._map[None] = (w, [self.class_])
+
+    def __init_str(self):
+        w = Text(self.frame_main, undo=True, maxundo=TEXT_MAX_UNDO)
+        w.pack(fill=tk.BOTH, expand=True)
+        self._map[None] = (w, [self.class_])
+
+    @property
+    def modified(self) -> bool:
+        """
+        Returns True if the GUI values have been modified.
+        """
+        current_values = self._read_gui_values()
+        return current_values != self._original_gui_data
+
     def update_window_title(self):
-        self.origin_window.title(f"{'New' if self.old_object_info is None else 'Edit'} {self.get_cls_name(self.class_)} object")
+        "Set's the window title according to edit context."
+        self.origin_window.title(f"{'New' if self.old_gui_data is None else 'Edit'} {self.get_cls_name(self.class_)} object")
 
     def close_frame(self):
         if self.allow_save and self.modified:
@@ -568,51 +361,6 @@ class NewObjectFrame(ttk.Frame):
                     self._cleanup()
         else:
             self._cleanup()
-
-    def load(self, object_info: ObjectInfo = None):
-        """
-        Loads the old object info data into the GUI.
-
-        Parameters
-        -------------
-        object_info: ObjectInfo
-            The ObjectInfo abstraction object to load. If None, it loads self.old_object_info.
-        """
-        if object_info is None:
-            object_info = self.old_object_info
-
-        data = object_info.data if self._map.get(None) is None else object_info
-
-        for attr, (widget, types_) in self._map.items():
-            if attr is not None:
-                if attr not in data:
-                    continue
-
-                val = data[attr]
-            else:
-                val = data  # Single value type
-
-            if isinstance(widget, ComboBoxObjects):
-                if val not in widget["values"]:
-                    widget.insert(tk.END, val)
-
-                widget.current(widget["values"].index(val))
-
-            elif isinstance(widget, ListBoxScrolled):
-                widget.insert(tk.END, *data)
-
-            elif isinstance(widget, tk.Text):
-                widget.insert(tk.END, data)
-
-            elif isinstance(widget, ttk.Spinbox):
-                widget.set(data)
-
-    @staticmethod
-    def _lambda(method, *args, **kwargs):
-        def _():
-            return method(*args, **kwargs)
-
-        return _
 
     def new_object_frame(
         self,
@@ -648,8 +396,208 @@ class NewObjectFrame(ttk.Frame):
 
         return __
 
-    def combo_edit_selected(self, combo: ComboBoxObjects, original_type = None):
-        def __():
+    def to_object(self, *, ignore_checks = False):
+        """
+        Creates an object from the GUI data.
+
+        Parameters
+        ------------
+        ignore_checks: bool
+            Don't check data validity.
+        """
+        raise NotImplementedError
+
+    def load(self, old_data: ObjectInfo = None):
+        """
+        Loads the old object info data into the GUI.
+
+        Parameters
+        -------------
+        old_data: Any
+            The old gui data to load.
+        """
+        raise NotImplementedError
+
+    def save(self):
+        """
+        Save the current object into the return widget and then close this frame.
+        """
+        try:
+            if not self.allow_save:
+                raise TypeError("Saving is not allowed in this context!")
+
+            object_ = self.to_object()
+            self._update_ret_widget(object_)
+            self._cleanup()
+        except Exception as exc:
+            tkdiag.Messagebox.show_error(
+                f"Could not save the object.\n\n{exc}",
+                "Saving error",
+                parent=self.origin_window
+            )
+
+    def rembember_gui_data(self):
+        """
+        Remembers GUI data for change checking.
+        """
+        self._original_gui_data = self._read_gui_values()
+
+    def _read_gui_values(self) -> Any:
+        """
+        Returns all GUI values.
+        """
+        raise NotImplementedError
+
+    def _cleanup(self):
+        self.origin_window.clean_object_edit_frame()
+
+    def _update_ret_widget(self, new: Any):
+        """
+        Save the newly created object into the return widget.
+
+        Parameters
+        -----------
+        new: Any
+            The newly created object.
+        """
+        raise NotImplementedError
+
+
+class NewObjectFrameStruct(NewObjectFrameBase):
+    """
+    Frame for inside the :class:`ObjectEditWindow` that allows object definition.
+
+    Parameters
+    -------------
+    class_: Any
+        The class we are defining for.
+    return_widget: ComboBoxObjects | ListBoxScrolled
+        The widget to insert the ObjectInfo into after saving.
+    parent: TopLevel
+        The parent window.
+    old: ObjectInfo
+        The old ObjectInfo object to edit.
+    check_parameters: bool
+        Check parameters (by creating the real object) upon saving.
+        This is ignored if editing a function instead of a class.
+    allow_save: bool
+        If False, will open in read-only mode.
+    additional_values: Dict[str, Any]
+        A mapping of additional values to be inserted into corresponding field.
+    """
+    def __init__(
+        self,
+        class_,
+        return_widget: Union[ComboBoxObjects, ListBoxScrolled],
+        parent = None,
+        old: ObjectInfo = None,
+        check_parameters: bool = True,
+        allow_save = True,
+        additional_values: dict = {},
+    ):
+        def get_annotations(class_) -> dict:
+            """
+            Returns class / function annotations including overrides.
+            """
+            annotations = {}
+            with suppress(AttributeError):
+                if inspect.isclass(class_):
+                    annotations = class_.__init__.__annotations__
+                else:
+                    annotations = class_.__annotations__
+
+            additional_annotations = ADDITIONAL_ANNOTATIONS.get(class_, {})
+            annotations = {**annotations, **additional_annotations}
+
+            if "return" in annotations:
+                del annotations["return"]
+
+            return annotations
+
+        super().__init__(class_, return_widget, parent, old, check_parameters, allow_save)
+        self._map: Dict[str, Tuple[ComboBoxObjects, Iterable[type]]] = {}
+        dpi_5 = dpi_scaled(5)
+
+        if not (annotations := get_annotations(class_)):
+            tkdiag.Messagebox.show_error("This object cannot be edited.", "Load error", parent=self)
+            self.origin_window.after_idle(self._cleanup)  # Can not clean the object before it has been added to list
+            return
+
+        # Template
+        @gui_except(parent=self)
+        def save_template():
+            filename = tkfile.asksaveasfilename(filetypes=[("JSON", "*.json")], parent=self)
+            if filename == "":
+                return
+
+            json_data = convert_to_json(self.to_object(ignore_checks=True))
+
+            if not filename.endswith(".json"):
+                filename += ".json"
+
+            with open(filename, "w", encoding="utf-8") as file:
+                json.dump(json_data, file, indent=2)
+
+            tkdiag.Messagebox.show_info(f"Saved to {filename}", "Finished", self)
+
+        @gui_except(parent=self)
+        def load_template():
+            filename = tkfile.askopenfilename(filetypes=[("JSON", "*.json")], parent=self)
+            if filename == "":
+                return
+
+            with open(filename, "r", encoding="utf-8") as file:
+                json_data: dict = json.load(file)
+                object_info = convert_from_json(json_data)
+                # Get class_ attribute if we have the ObjectInfo type, if not just compare the actual type
+                if object_info.class_ is not self.class_:
+                    raise TypeError(
+                        f"The selected template is not a {self.class_.__name__} template.\n"
+                        f"The requested template is for type: {object_info.class_.__name__}!"
+                    )
+
+                self.load(object_info)
+
+        bnt_menu_template = ttk.Menubutton(self.frame_toolbar, text="Template")
+        menu = ttk.Menu(bnt_menu_template)
+        menu.add_command(label="Load template", command=load_template)
+        menu.add_command(label="Save template", command=save_template)
+        bnt_menu_template.configure(menu=menu)
+        bnt_menu_template.pack(side="left")
+
+        def fill_values(k: str, entry_types: list, menu: ttk.Menu, combo: ComboBoxObjects):
+            "Fill ComboBox values based on types in ``entry_types`` and create New <object_type> buttons"
+            last_list_type = None
+            for entry_type in entry_types:
+                if get_origin(entry_type) is Literal:
+                    combo["values"] = get_args(entry_type)
+                elif entry_type is bool:
+                    combo.insert(tk.END, True)
+                    combo.insert(tk.END, False)
+                elif issubclass_noexcept(entry_type, Enum):
+                    combo["values"] = [en for en in entry_type]
+                elif entry_type is type(None):
+                    if bool not in entry_types:
+                        combo.insert(tk.END, None)
+                else:  # Type not supported, try other types
+                    if get_origin(entry_type) in {list, tuple, set, Iterable, ABCIterable}:
+                        last_list_type = entry_type
+
+                    if self.allow_save:
+                        menu.add_command(
+                            label=f"New {self.get_cls_name(entry_type)}",
+                            command=self._lambda(self.new_object_frame, entry_type, combo)
+                        )
+
+            # Additional values to be inserted into ComboBox
+            for value in additional_values.get(k, []):
+                combo.insert(tk.END, value)
+
+            # The class of last list like type. Needed when "Edit selected" is used
+            # since we don't know what type it was
+            return last_list_type
+
+        def edit_selected(combo: ComboBoxObjects, original_type = None):
             selection = combo.get()
 
             if isinstance(selection, list):
@@ -659,16 +607,112 @@ class NewObjectFrame(ttk.Frame):
             else:
                 return self.new_object_frame(type(selection), combo, old=selection)
 
-        return __
+        for (k, v) in annotations.items():
+            # Init widgets
+            entry_types = self.convert_types(v)
+            frame_annotated = ttk.Frame(self.frame_main)
+            frame_annotated.pack(fill=tk.BOTH, expand=True)
+            ttk.Label(frame_annotated, text=k, width=15).pack(side="left")
 
-    def _cleanup(self):
-        self.origin_window.clean_object_edit_frame()
+            bnt_menu = ttk.Menubutton(frame_annotated)
+            menu = tk.Menu(bnt_menu)
+            bnt_menu.configure(menu=menu)
+            bnt_menu.pack(side="right")
 
-    def _gui_to_object(self, *, ignore_checks = False):
+            w = combo = ComboBoxObjects(frame_annotated)
+            combo.pack(fill=tk.X, side="right", expand=True, padx=dpi_5, pady=dpi_5)
+
+            # Fill values
+            last_list_type = fill_values(k, entry_types, menu, combo)
+
+            # Edit / view command button
+            menu.add_command(
+                label=f"{'Edit' if self.allow_save else 'View'} selected",
+                command=self._lambda(edit_selected, w, last_list_type)
+            )
+            self._map[k] = (w, entry_types)
+
+        self.init_method_frame()
+        if old is not None:  # Edit
+            self.load()
+
+        self.rembember_gui_data()
+
+    def init_method_frame(self):
+        "Inits the frame that supports method executino on live objects."
+        if (
+            self.old_gui_data is None or
+            # getattr since class_ can also be non ObjectInfo
+            getattr(self.old_gui_data, "real_object", None) is None or
+            (available_methods := EXECUTABLE_METHODS.get(self.class_)) is None
+        ):
+            return
+
+        def execute_method():
+            async def runner():
+                method = frame_execute_method.combo.get()
+                if not isinstance(method, ObjectInfo):  # String typed in that doesn't match any names
+                    tkdiag.Messagebox.show_error("No method selected!", "Selection error")
+                    return
+
+                method_param = convert_to_objects(method.data, skip_real_conversion=True)
+                connection = get_connection()
+                # Call the method though the connection manager
+                await connection.execute_method(
+                    self.old_gui_data.real_object,
+                    method.class_.__name__,
+                    **method_param,
+                )
+
+            async_execute(runner(), parent_window=self.origin_window)
+
+        dpi_5, dpi_10 = dpi_scaled(5), dpi_scaled(10)
+        frame_method = ttk.LabelFrame(self, text="Method execution", padding=(dpi_5, dpi_10), bootstyle=ttk.INFO)
+        ttk.Button(frame_method, text="Execute", command=execute_method).pack(side="left")
+        combo_values = []
+        for unbound_meth in available_methods:
+            combo_values.append(ObjectInfo(unbound_meth, {}))
+
+        def new_object_frame_with_values(class_, widget, *args, **kwargs):
+            """
+            Middleware method for opening a new object frame, that fills in additional
+            values for the specific method (class_) we are editing.
+            """
+            extra_values = ADDITIONAL_PARAMETER_VALUES.get(class_, {}).copy()
+            for k, v in extra_values.items():
+                extra_values[k] = v(self.old_gui_data)
+
+            return self.new_object_frame(class_, widget, *args, **kwargs, additional_values=extra_values)
+
+        frame_execute_method = ComboEditFrame(
+            new_object_frame_with_values,
+            combo_values,
+            master=frame_method
+        )
+        frame_execute_method.pack(side="right", fill=tk.X, expand=True)
+        frame_method.pack(fill=tk.X)
+
+    def load(self, old_data: ObjectInfo = None):
+        if old_data is None:
+            old_data = self.old_gui_data
+
+        data = old_data.data
+        for attr, (widget, types_) in self._map.items():
+            if attr not in data:
+                continue
+
+            val = data[attr]
+
+            if val not in widget["values"]:
+                widget.insert(tk.END, val)
+
+            widget.current(widget["values"].index(val))
+
+    def to_object(self, *, ignore_checks=False):
         map_ = {}
+        widget: ComboBoxObjects
         for attr, (widget, types_) in self._map.items():
             value = widget.get()
-
             if isinstance(value, str):  # Ignore empty values
                 if not len(value):
                     continue
@@ -681,55 +725,49 @@ class NewObjectFrame(ttk.Frame):
 
             map_[attr] = value
 
-        single_value = map_.get(None, ...)
-        if single_value is not Ellipsis:
-            object_ = single_value
-        else:
-            object_ = ObjectInfo(
-                self.class_,
-                map_,
-                # Don't erase the bind to the real object in case this is an edit of an existing ObjectInfo
-                None if self.old_object_info is None else self.old_object_info.real_object
-            )
-            if not ignore_checks and self.check_parameters and inspect.isclass(self.class_):  # Only check objects
-                convert_to_objects(object_)  # Tries to create instances to check for errors
+        # Abstraction of the underlaying object
+        object_ = ObjectInfo(
+            self.class_,
+            map_,
+            # Don't erase the bind to the real object in case this is an edit of an existing ObjectInfo
+            None if self.old_gui_data is None else self.old_gui_data.real_object
+        )
+        if not ignore_checks and self.check_parameters and inspect.isclass(self.class_):  # Only check objects
+            convert_to_objects(object_)  # Tries to create instances to check for errors
 
         return object_
 
-    def _update_old_object(self, new: Union[ObjectInfo, Any]):
-        if self.old_object_info is not None:
+    def _read_gui_values(self) -> dict:
+        values = {}
+        for attr, (widget, types_) in self._map.items():
+            value = widget.get()
+            if isinstance(value, (list, tuple, set)):  # Copy lists else the values would change in the original state
+                value = copy.copy(value)
+
+            values[attr] = value
+
+        return values
+
+    def _update_ret_widget(self, new: Any):
+        if self.old_gui_data is not None:
             ret_widget = self.return_widget
             # Ignore if not in list (Combobox allows to type values directly in instead of inserting them)
             # thus when edit is clicked, the old information is loaded into the object edit info, howver the actual
             # value while it was writen inside the combobox is not actually present in the list of it's values
             with suppress(ValueError):
                 if isinstance(ret_widget, ListBoxScrolled):
-                    ind = ret_widget.get().index(self.old_object_info)
+                    ind = ret_widget.get().index(self.old_gui_data)
                 else:
-                    ind = ret_widget["values"].index(self.old_object_info)
+                    ind = ret_widget["values"].index(self.old_gui_data)
 
                 ret_widget.delete(ind)
+        else:
+            ind = tk.END
 
         self.return_widget.insert(ind, new)
         if isinstance(self.return_widget, ComboBoxObjects):
-            self.return_widget.current(self.return_widget["values"].index(new))
+            self.return_widget.current(ind)
+        else:
+            self.return_widget.selection_set(ind)
 
-        self.old_object_info = new
-
-    def save(self):
-        """
-        Saves the GUI data into ObjectInfo and place it in the return widget.
-        """
-        try:
-            if not self.allow_save:
-                raise TypeError("Saving is not allowed in this context!")
-
-            object_ = self._gui_to_object()
-            self._update_old_object(object_)
-            self._cleanup()
-        except Exception as exc:
-            tkdiag.Messagebox.show_error(
-                f"Could not save the object.\n\n{exc}",
-                "Saving error",
-                parent=self.origin_window
-            )
+        self.old_gui_data = new

--- a/src/daf_gui/storage.py
+++ b/src/daf_gui/storage.py
@@ -81,6 +81,9 @@ class ListBoxObjects(tk.Listbox):
             super().delete(*range_)
             del self._original_items[range_[0]:range_[1] + 1]
 
+    def size(self) -> int:
+        return len(self._original_items)
+
     @gui_confirm_action(True)
     def delete_selected(self):
         sel: List[int] = self.curselection()
@@ -127,26 +130,13 @@ class ListBoxObjects(tk.Listbox):
             tkdiag.Messagebox.show_error("Select ONE item!", "Selection error", parent=self)
 
 
-class ListBoxScrolled(ttk.Frame):
-    def __init__(self, parent, *args, **kwargs):
-        super().__init__(parent)
-        listbox = ListBoxObjects(self, *args, **kwargs)
-        self.listbox = listbox
-
-        listbox.pack(side="left", fill=tk.BOTH, expand=True)
-
+class ListBoxScrolled(ListBoxObjects):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         scrollbar = ttk.Scrollbar(self)
         scrollbar.pack(side=tk.RIGHT, fill=tk.BOTH)
-        scrollbar.config(command=listbox.yview)
-
-        listbox.config(yscrollcommand=scrollbar.set)
-
-    def __getattr__(self, __value: str):
-        """
-        Getter method that only get's called if the current
-        implementation does not have the requested attribute.
-        """
-        return getattr(self.listbox, __value)
+        scrollbar.config(command=self.yview)
+        self.config(yscrollcommand=scrollbar.set)
 
 
 class ComboBoxObjects(ttk.Combobox):
@@ -174,6 +164,10 @@ class ComboBoxObjects(ttk.Combobox):
             self._original_items.insert(index, element)
 
         self["values"] = self._original_items
+
+    def size(self) -> int:
+        "Returns number of elements inside the ComboBox"
+        return len(self._original_items)
 
     def __setitem__(self, key: str, value) -> None:
         if key == "values":

--- a/src/daf_gui/utilities.py
+++ b/src/daf_gui/utilities.py
@@ -2,7 +2,7 @@
 Module contains interface to run async tasks from GUI.
 """
 from typing import Coroutine, Callable
-from asyncio import Queue, Task, Semaphore, Lock
+from asyncio import Queue, Task
 
 from daf import trace, TraceLEVELS
 


### PR DESCRIPTION
Changes:

- GUI:

  - Template backups for each structured objects.
  - Rearanging of list items inside GUI listboxes
  - Connection timeout to a remote core is now 10 minutes for large datasets.
  - Dictionary editing - GUI nows allows to edit / view dictionary types (JSON). This could eg. be used
    to view SQL log's content which is saved to the database into JSON format.