### PR TITLE
Per-channel remove_after

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -35,9 +35,18 @@ Releases
 v2.10
 ====================
 - Moderation timeout handling (messages resume one minute after moderation timeout expiry)
+- :class:`~daf.message.TextMESSAGE` and :class:`~daf.message.VoiceMESSAGE`'s ``remove_after`` parameter:
+
+  - If integer, it will now work independently for each channel and will only decrement on successful sends.
+  - If :class:`~datetime.datetime` or :class:`~datetime.timedelta`, it will work the same as before.
+
+- New property: :py:attr:`~daf.message.TextMESSAGE.remaining_before_removal`, :py:attr:`~daf.message.VoiceMESSAGE.remaining_before_removal`,
+  :py:attr:`~daf.message.DirectMESSAGE.remaining_before_removal`
+
 - GUI:
 
-  - deprecation notices are now a button
+  - deprecation notices are now a button.
+  - Certain fields are now masked with '*' when not editing the object.
 
 
 v2.9.2

--- a/src/daf/guild.py
+++ b/src/daf/guild.py
@@ -233,6 +233,7 @@ class _BaseGUILD:
         ValueError
             Raised when the message is not present in the list.
         """
+        trace(f"Removing message {message} from {self}", TraceLEVELS.DEBUG)
         message._delete()
         self._messages.remove(message)
 

--- a/src/daf/message/voice_based.py
+++ b/src/daf/message/voice_based.py
@@ -79,13 +79,14 @@ class VoiceMESSAGE(BaseChannelMessage):
         The data types of this parameter can be:
 
             - AUDIO object.
-            - Function that accepts any amount of parameters and returns an AUDIO object.
-              To pass a function, YOU MUST USE THE :ref:`data_function` decorator on the function.
+            - Function that accepts any amount of parameters and returns an AUDIO object. To pass a function, YOU MUST USE THE :ref:`data_function` decorator on the function.
+
     channels: Union[Iterable[Union[int, discord.VoiceChannel]], daf.message.AutoCHANNEL]
+        Channels that it will be advertised into (Can be snowflake ID or channel objects from PyCord).
+
         .. versionchanged:: v2.3
             Can also be :class:`~daf.message.AutoCHANNEL`
 
-        Channels that it will be advertised into (Can be snowflake ID or channel objects from PyCord).
     volume: Optional[int]
         The volume (0-100%) at which to play the audio. Defaults to 50%. This was added in v2.0.0
     start_in: Optional[timedelta | datetime]
@@ -94,9 +95,14 @@ class VoiceMESSAGE(BaseChannelMessage):
     remove_after: Optional[Union[int, timedelta, datetime]]
         Deletes the message after:
 
-        * int - provided amounts of sends
+        * int - provided amounts of successful sends to seperate channels.
         * timedelta - the specified time difference
         * datetime - specific date & time
+
+        .. versionchanged:: v2.10
+
+            Parameter ``remove_after`` of int type will now work at a channel level and
+            it nows means the SUCCESSFUL number of sends into each channel.
     """
 
     __slots__ = (


### PR DESCRIPTION
Pull requests changes the ``remove_after`` parameter of TextMESSAGE and VoiceMESSAGE to work on per-channel basis.
When a channel send counter reaches the ``remove_after`` parameter, the channel is automatically removed and the message when all channels are removed. The counter increments on each successful send to the channel.

Changes:

- [x] ``remove_after`` to remove ``[Text/Voice]MESSAGE`` after reaching N successful sends on all channels.
- [x] ``remove_after`` to remove ``DirectMESSAGE`` after reaching N successful sends.