### PR TITLE
Save edited values by index

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -47,6 +47,7 @@ v2.10
 
   - deprecation notices are now a button.
   - Certain fields are now masked with '*' when not editing the object.
+  - Old data that is being updated will now be updated by index
 
 
 v2.9.2

--- a/src/daf_gui/extra.py
+++ b/src/daf_gui/extra.py
@@ -169,7 +169,7 @@ for name in dir(daf):
 
             ADDITIONAL_WIDGETS[item].extend([
                 AdditionalWidget(ttk.Button, setup_additional_live_update, text="Live update"),
-                AdditionalWidget(ttk.Button, setup_additional_live_refresh, text="Refresh")
+                AdditionalWidget(ttk.Button, setup_additional_live_refresh, text="Refresh"),
             ])
 
 

--- a/src/daf_gui/object.py
+++ b/src/daf_gui/object.py
@@ -122,6 +122,12 @@ class NewObjectFrameBase(ttk.Frame):
         self.allow_save = allow_save  # Allow save or not allow (eg. viewing SQL data)
         self.old_gui_data = old_data  # Set in .load
 
+        editing_index = self.return_widget.current()
+        if editing_index == -1:
+            editing_index = None
+
+        self.editing_index = editing_index  # The index of old_gui_data inside the return widget
+
         super().__init__(master=parent)
         self.init_toolbar_frame(class_)
         self.init_main_frame()
@@ -337,15 +343,8 @@ class NewObjectFrameBase(ttk.Frame):
         ind = self.return_widget.count()
         if self.old_gui_data is not None:
             ret_widget = self.return_widget
-            # Ignore if not in list (Combobox allows to type values directly in instead of inserting them)
-            # thus when edit is clicked, the old information is loaded into the object edit info, howver the actual
-            # value while it was writen inside the combobox is not actually present in the list of it's values
-            with suppress(ValueError):
-                if isinstance(ret_widget, ListBoxScrolled):
-                    ind = ret_widget.get().index(self.old_gui_data)
-                else:
-                    ind = ret_widget["values"].index(self.old_gui_data)
-
+            if self.editing_index is not None:  # The index of edited item inside return widget
+                ind = self.editing_index
                 ret_widget.delete(ind)
 
         self.return_widget.insert(ind, new)

--- a/src/daf_gui/storage.py
+++ b/src/daf_gui/storage.py
@@ -39,6 +39,11 @@ class ListBoxObjects(tk.Listbox):
         self.bind("<Delete>", lambda e: self.delete_selected())
         self.bind("<Control-v>", lambda e: self.paste_from_clipboard())
 
+    def current(self) -> int:
+        "Returns index of the first currently selected element or -1 if none selected."
+        selection = self.curselection()
+        return selection[0] if len(selection) else -1
+
     def get(self, first: int = 0, last: int = None) -> list:
         slice_range = slice(first, last)
         return self._original_items[slice_range]


### PR DESCRIPTION
The PR introduces a change in the graphical interface, that results in objects being saved, to be saved inserted into previous widget by original index instead of searching for a value match.