### PR TITLE
feat: Announcement channel publish inside ``TextMESSAGE``

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -42,6 +42,8 @@ v2.10
 
 - New property: :py:attr:`~daf.message.TextMESSAGE.remaining_before_removal`, :py:attr:`~daf.message.VoiceMESSAGE.remaining_before_removal`,
   :py:attr:`~daf.message.DirectMESSAGE.remaining_before_removal`
+- New parameter: ``auto_publish`` to :class:`~daf.message.TextMESSAGE` for automatically publishing messages sent to
+  announcement (news) channels.
 
 - GUI:
 

--- a/src/_discord/http.py
+++ b/src/_discord/http.py
@@ -358,7 +358,8 @@ class HTTPClient:
 
                         # we are being rate limited
                         if response.status == 429:
-                            if not response.headers.get("Via") or isinstance(data, str) or ("code" in data and data["code"] == 20016):
+                            retry_after: float = data.get("retry_after", 0)
+                            if not response.headers.get("Via") or isinstance(data, str) or ("code" in data and data["code"] == 20016) or retry_after > 30:
                                 # Banned by Cloudflare more than likely.
                                 raise HTTPException(response, data)
 
@@ -368,7 +369,6 @@ class HTTPClient:
                             )
 
                             # sleep a bit
-                            retry_after: float = data["retry_after"]
                             _log.warning(fmt, retry_after, bucket)
 
                             # check if it's a global rate limit


### PR DESCRIPTION
Changes
- Added ``auto_publish`` bool parameter to ``daf.message.TextMESSAGE``, which will cause the message to be automatically published when sent to an announcement (news) channel.