### PR TITLE
feat: Fixed default intents, improved safety of invite tracking.

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -34,6 +34,11 @@ Releases
 
 v2.10
 ====================
+- Intents:
+  
+  - Added warnings for missing intents.
+  - Intents.members is by default now disabled.
+
 - |BREAK_CH| Removed deprecated feature - YouTube streaming.
 - Deprecated :class:`daf.dtypes.AUDIO`, replaced with :class:`daf.dtypes.FILE`.
 - :class:`daf.dtypes.FILE` now accepts binary data as well and will load the data from ``filename`` at creation
@@ -55,6 +60,7 @@ v2.10
   - Certain fields are now masked with '*' when not editing the object.
   - Old data that is being updated will now be updated by index
   - View properties of trackable objects. This can be used to, eg. view the channels AutoCHANNEL found.
+  - 'Load default' button when editing :class:`discord.Intents` object.
 
 
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -53,6 +53,8 @@ v2.10
   :py:attr:`~daf.message.DirectMESSAGE.remaining_before_removal`
 - New parameter: ``auto_publish`` to :class:`~daf.message.TextMESSAGE` for automatically publishing messages sent to
   announcement (news) channels.
+- Time between each guild join is now 45 seconds.
+- Selenium can now be used though remote, however it is not recommended.
 
 - GUI:
 

--- a/docs/source/guide/GUI/analytics.rst
+++ b/docs/source/guide/GUI/analytics.rst
@@ -90,6 +90,8 @@ These are :ref:`Logs frame (invites)` and :ref:`Counts frame (invites)` .
     To use invite link tracking, users need to enable the privileged intent 'SERVER MEMBERS INTENT' and
     also set the ``members`` intent to True inside the ``intents`` parameter of :class:`~daf.client.ACCOUNT`.
 
+    Invite link tracking is **bot account** only and does not work on user accounts.
+
 
 Logs frame (invites)
 -----------------------

--- a/docs/source/guide/GUI/analytics.rst
+++ b/docs/source/guide/GUI/analytics.rst
@@ -87,8 +87,9 @@ These are :ref:`Logs frame (invites)` and :ref:`Counts frame (invites)` .
 .. warning::
 
     To track invite links, the Members intent (event setting) is needed.
-    To use invite link tracking, users need to enable the privileged intent 'SERVER MEMBERS INTENT' and
-    also set the ``members`` intent to True inside the ``intents`` parameter of :class:`~daf.client.ACCOUNT`.
+    To use invite link tracking, users need to enable the privileged intent 'SERVER MEMBERS INTENT' inside
+    the Discord developer portal and also set the ``members`` intent to True
+    inside the ``intents`` parameter of :class:`~daf.client.ACCOUNT`.
 
     Invite link tracking is **bot account** only and does not work on user accounts.
 

--- a/docs/source/guide/GUI/analytics.rst
+++ b/docs/source/guide/GUI/analytics.rst
@@ -84,6 +84,12 @@ Invite link tracking
 The invite tracking is split into 2 sub-sections.
 These are :ref:`Logs frame (invites)` and :ref:`Counts frame (invites)` .
 
+.. warning::
+
+    To track invite links, the Members intent (event setting) is needed.
+    To use invite link tracking, users need to enable the privileged intent 'SERVER MEMBERS INTENT' and
+    also set the ``members`` intent to True inside the ``intents`` parameter of :class:`~daf.client.ACCOUNT`.
+
 
 Logs frame (invites)
 -----------------------

--- a/docs/source/guide/core/logging.rst
+++ b/docs/source/guide/core/logging.rst
@@ -21,6 +21,8 @@ The logging module is responsible for 2 types of logging:
     To use invite link tracking, users need to enable the privileged intent 'SERVER MEMBERS INTENT' and
     also set the ``members`` intent to True inside the ``intents`` parameter of :class:`~daf.client.ACCOUNT`.
 
+    Invite link tracking is **bot account** only and does not work on user accounts.
+
 
 Logging can be enabled for each :class:`~daf.guild.GUILD` / :class:`~daf.guild.USER` if the ``logging`` parameter is
 set to ``True``.

--- a/docs/source/guide/core/logging.rst
+++ b/docs/source/guide/core/logging.rst
@@ -15,12 +15,19 @@ The logging module is responsible for 2 types of logging:
 1. **Messages** - Logs (attempts of) sent messages
 2. **Invite links** - Tracks new member joins with configured invite links.
 
+.. warning::
+
+    To track invite links, the Members intent (event setting) is needed.
+    To use invite link tracking, users need to enable the privileged intent 'SERVER MEMBERS INTENT' and
+    also set the ``members`` intent to True inside the ``intents`` parameter of :class:`~daf.client.ACCOUNT`.
+
+
 Logging can be enabled for each :class:`~daf.guild.GUILD` / :class:`~daf.guild.USER` if the ``logging`` parameter is
 set to ``True``.
 
 .. note:: 
     
-    **Invite links** will be tracked regardless of the ``logging`` parameter. Invite link tracking is configured
+    **Invite links** will be tracked regardless of the GUILD's ``logging`` parameter. Invite link tracking is configured
     solely by the ``invite_track`` parameter inside :class:`~daf.guild.GUILD`.
 
 

--- a/docs/source/guide/core/logging.rst
+++ b/docs/source/guide/core/logging.rst
@@ -18,8 +18,9 @@ The logging module is responsible for 2 types of logging:
 .. warning::
 
     To track invite links, the Members intent (event setting) is needed.
-    To use invite link tracking, users need to enable the privileged intent 'SERVER MEMBERS INTENT' and
-    also set the ``members`` intent to True inside the ``intents`` parameter of :class:`~daf.client.ACCOUNT`.
+    To use invite link tracking, users need to enable the privileged intent 'SERVER MEMBERS INTENT' inside
+    the Discord developer portal and also set the ``members`` intent to True
+    inside the ``intents`` parameter of :class:`~daf.client.ACCOUNT`.
 
     Invite link tracking is **bot account** only and does not work on user accounts.
 

--- a/docs/source/guide/core/web.rst
+++ b/docs/source/guide/core/web.rst
@@ -66,7 +66,7 @@ The web layer beside login with username and password, also allows (semi) automa
 
 To use this feature, users need to create an :class:`~daf.guild.AutoGUILD` instance, where they pass the ``auto_join``
 parameter. ``auto_join`` parameter is a :class:`~daf.web.GuildDISCOVERY` object, which can be configured how it should
-search for new guilds.
+search for new guilds. DAF will join a new guild every 45 seconds until the limit is reached.
 
 .. warning::
     

--- a/src/daf/client.py
+++ b/src/daf/client.py
@@ -135,7 +135,6 @@ class ACCOUNT:
         # If intents not passed, enable default
         if intents is None:
             intents = discord.Intents.default()
-            intents.members = True
 
         self.intents = intents
         self._running = False
@@ -250,6 +249,17 @@ class ACCOUNT:
         RuntimeError
             Unable to login to Discord.
         """
+        intents = self.intents
+        if not intents.members:
+            trace("Members intent is disabled, it is needed for invite link tracking", TraceLEVELS.WARNING)
+
+        if not intents.invites:
+            trace("Invites intent is disabled, it is needed for invite link tracking", TraceLEVELS.WARNING)
+
+        if not intents.guilds:
+            self.intents.guilds = True
+            trace("Guilds intent is disabled. Enabling it since it's needed.", TraceLEVELS.WARNING)
+
         self._deleted = False
         connector = None
         if self.proxy is not None:

--- a/src/daf/client.py
+++ b/src/daf/client.py
@@ -65,8 +65,18 @@ class ACCOUNT:
         The Discord account's token
     is_user : Optional[bool] =False
         Declares that the ``token`` is a user account token ("self-bot")
-    intents: Optional[discord.Intents]=discord.Intents.default()
-        Discord Intents (settings of events that the client will subscribe to)
+    intents: Optional[discord.Intents]
+        Discord Intents (settings of events that the client will subscribe to).
+        Defeaults to everything enabled except ``members``, ``presence`` and ``message_content``, as those
+        are privileged events, which need to be enabled though Discord's developer settings for each bot.
+
+        .. warning::
+
+            For invite link tracking to work, it is required to set ``members`` intents to True.
+
+            Intent ``guilds`` is also required for AutoGUILD and AutoCHANNEL, however it is automatically forced
+            to True, as it is not a priveleged intent.
+
     proxy: Optional[str]=None
         The proxy to use when connecting to Discord.
 

--- a/src/daf/convert.py
+++ b/src/daf/convert.py
@@ -24,6 +24,7 @@ from . import client
 from . import guild
 from . import message
 from . import logging
+from . import web
 
 
 __all__ = (
@@ -55,6 +56,7 @@ CONVERSION_ATTRS = {
             "_update_sem": asyncio.Semaphore(1),
             "_running": False,
             "_client": None,
+            "_ws_task": None,
         },
     },
     guild.AutoGUILD: {
@@ -72,6 +74,19 @@ CONVERSION_ATTRS = {
             "removed_channels": set(),
             "channel_getter": None,
         },
+    },
+    web.SeleniumCLIENT: {
+        "attrs": attributes.get_all_slots(web.SeleniumCLIENT),
+        "attrs_restore": {
+            "driver": None
+        }
+    },
+    web.GuildDISCOVERY: {
+        "attrs": attributes.get_all_slots(web.GuildDISCOVERY),
+        "attrs_restore": {
+            "session": None,
+            "browser": None
+        }
     },
     logging.LoggerSQL: {
         "attrs": ["_daf_id"]

--- a/src/daf/guild.py
+++ b/src/daf/guild.py
@@ -426,6 +426,7 @@ class GUILD(_BaseGUILD):
         .. versionadded:: 2.7
 
         List of invite IDs to be tracked for member join count inside the guild.
+        **Bot account** only, does not work on user accounts.
 
         .. note::
 

--- a/src/daf/guild.py
+++ b/src/daf/guild.py
@@ -433,6 +433,13 @@ class GUILD(_BaseGUILD):
             tracking to fully function. *Manage Server* is needed for getting information about invite links,
             *Manage Channels* is needed to delete the invite from the list if it has been deleted,
             however tracking still works without it.
+
+        .. warning::
+
+            For GUILD to receive events about member joins, ``members`` intent is required to be True inside
+            the ``intents`` parameters of :class:`daf.client.ACCOUNT`.
+            This is a **privileged intent** that also needs to be enabled though Discord's developer portal for each bot.
+            After it is enabled, you can set it to True .
     """
     __slots__ = (
         "update_semaphore",

--- a/src/daf/guild.py
+++ b/src/daf/guild.py
@@ -519,6 +519,7 @@ class GUILD(_BaseGUILD):
     async def add_message(self, message: Union[TextMESSAGE, VoiceMESSAGE]):
         return await super().add_message(message)
 
+    @async_util.with_semaphore("update_semaphore")
     async def _on_member_join(self, member: discord.Member):
         counts = self.join_count
         invites = await self.get_invites()
@@ -532,6 +533,7 @@ class GUILD(_BaseGUILD):
                 await logging.save_log(self.generate_log_context(), None, None, invite_ctx)
                 return
 
+    @async_util.with_semaphore("update_semaphore")
     async def _on_invite_delete(self, invite: discord.Invite):
         if invite.id in self.join_count:
             del self.join_count[invite.id]
@@ -808,10 +810,6 @@ class AutoGUILD:
         Set to True if you want the guilds generated to log
         sent messages.
     interval: Optional[timedelta] = timedelta(minutes=1)
-        .. deprecated:: v2.10
-
-            Scheduled for removal in v2.11
-
         Interval at which to scan for new guilds.
     auto_join: Optional[web.GuildDISCOVERY] = None
         .. versionadded:: v2.5

--- a/src/daf/guild.py
+++ b/src/daf/guild.py
@@ -29,7 +29,7 @@ __all__ = (
 GUILD_ADVERT_STATUS_SUCCESS = 0
 GUILD_ADVERT_STATUS_ERROR_REMOVE_ACCOUNT = None
 
-GUILD_JOIN_INTERVAL = timedelta(seconds=25)
+GUILD_JOIN_INTERVAL = timedelta(seconds=45)
 GUILD_MAX_AMOUNT = 100
 
 globals_ = globals()

--- a/src/daf/message/base.py
+++ b/src/daf/message/base.py
@@ -456,10 +456,6 @@ class AutoCHANNEL:
             excluded from match.
 
     interval: Optional[timedelta] = timedelta(minutes=5)
-        .. deprecated:: v2.10
-
-            Scheduled for removal in v2.11
-
         Interval at which to scan for new channels.
     """
 
@@ -477,17 +473,7 @@ class AutoCHANNEL:
     def __init__(self,
                  include_pattern: str,
                  exclude_pattern: Optional[str] = None,
-                 interval: Optional[timedelta] = None) -> None:
-
-        if interval is not None:
-            trace(
-                "Parameter 'interval' inside AutoCHANNEL is scheduled for removal is deprecated since\n"
-                "v2.10 and deprecated and scheduled for removal in v2.10.",
-                TraceLEVELS.DEPRECATED
-            )
-        else:
-            interval = timedelta(seconds=5)
-
+                 interval: Optional[timedelta] = timedelta(minutes=1)) -> None:
         # Remove spaces around OR
         self.include_pattern = re.sub(r"\s*\|\s*", '|', include_pattern) if include_pattern else None
         self.exclude_pattern = re.sub(r"\s*\|\s*", '|', exclude_pattern) if exclude_pattern else None

--- a/src/daf/web.py
+++ b/src/daf/web.py
@@ -110,6 +110,14 @@ class SeleniumCLIENT:
     proxy: str
         The proxy url to use when connecting to Chrome.
     """
+    __slots__ = (
+        "_username",
+        "_password",
+        "_proxy",
+        "_token",
+        "driver",
+    )
+
     def __init__(self,
                  username: str,
                  password: str,

--- a/src/daf_gui/extra.py
+++ b/src/daf_gui/extra.py
@@ -188,6 +188,23 @@ def setup_additional_live_properties(w: ttk.Menubutton, frame):
     w.pack(side="right", padx=dpi_scaled(2))
 
 
+def setup_additional_widget_default_intents(w: ttk.Button, frame):
+    def _callback(*args):
+        default = discord.Intents.default()
+        map_: dict = frame._map.copy()
+        del map_["kwargs"]
+
+        # v = (widget, annotated_types)
+        # k = parameter name
+        for k, v in map_.items():
+            widget, _ = v
+            widget.set(str(getattr(default, k)))
+
+    w.configure(command=_callback)
+    ToolTip(w, text="Enable everything except privileged intents.", topmost=True)
+    w.pack(side="right")
+
+
 # Map that maps the instance we are defining class to a list of additional objects.
 ADDITIONAL_WIDGETS = {
     dt.datetime: [AdditionalWidget(ttk.Button, setup_additional_widget_datetime, text="Select date")],
@@ -196,6 +213,7 @@ ADDITIONAL_WIDGETS = {
     daf.LoggerJSON: [AdditionalWidget(ttk.Button, setup_additional_widget_file_chooser_logger, text="Select folder")],
     daf.LoggerCSV: [AdditionalWidget(ttk.Button, setup_additional_widget_file_chooser_logger, text="Select folder")],
     daf.AUDIO: [AdditionalWidget(ttk.Button, setup_additional_widget_file_chooser, text="File browse")],
+    discord.Intents: [AdditionalWidget(ttk.Button, setup_additional_widget_default_intents, text="Load default")]
 }
 
 for name in dir(daf):

--- a/src/daf_gui/object.py
+++ b/src/daf_gui/object.py
@@ -634,13 +634,14 @@ class NewObjectFrameStruct(NewObjectFrameBase):
 
             map_[attr] = value
 
-        # Abstraction of the underlaying object
-        object_ = ObjectInfo(
-            self.class_,
-            map_,
+        extra_args = {}
+        if (old_gui_data := self.old_gui_data) is not None:
             # Don't erase the bind to the real object in case this is an edit of an existing ObjectInfo
-            self.old_gui_data.real_object if self.old_gui_data is not None else None
-        )
+            extra_args["real_object"] = old_gui_data.real_object
+            # Also don't erase any saved properties if received from a live object.
+            extra_args["property_map"] = old_gui_data.property_map
+
+        object_ = ObjectInfo(self.class_, map_, **extra_args)  # Abstraction of the underlaying object
         if not ignore_checks and self.check_parameters and inspect.isclass(self.class_):  # Only check objects
             # Cache the object created for faster
             convert_to_objects(object_, cached=True)  # Tries to create instances to check for errors

--- a/src/daf_gui/object.py
+++ b/src/daf_gui/object.py
@@ -75,8 +75,6 @@ ADDITIONAL_PARAMETER_VALUES = {
 DEPRECATION_NOTICES = {
     daf.AUDIO: [("daf.dtypes.AUDIO", "2.12", "Replaced with daf.dtypes.FILE")],
     daf.VoiceMESSAGE: [("daf.dtypes.AUDIO as type for data parameter", "2.12", "Replaced with daf.dtypes.FILE")],
-    daf.AutoCHANNEL: [("Interval parameter", "2.11", "Event based refresh.")],
-    daf.AutoGUILD: [("Interval parameter", "2.11", "Event based refresh.")],
 }
 
 

--- a/src/daf_gui/storage.py
+++ b/src/daf_gui/storage.py
@@ -175,7 +175,6 @@ class ComboBoxObjects(ttk.Combobox):
     def insert(self, index: Union[int, str], element: Any) -> None:
         if index == tk.END:
             self._original_items.append(element)
-            index = len(self._original_items)
         else:
             self._original_items.insert(index, element)
 

--- a/testing/test_remote.py
+++ b/testing/test_remote.py
@@ -51,4 +51,4 @@ async def test_http(accounts, guilds):
     # Test get_accounts
     new_accounts = await client.get_accounts()
     for i in range(len(new_accounts)):
-        compare_objects(new_accounts[i], accounts[i], {"_deleted", "_client", "_daf_id"})
+        compare_objects(new_accounts[i], accounts[i], {"_deleted", "_client", "_daf_id", "_ws_task"})


### PR DESCRIPTION
Pull request type:
- [x] Feature
- [ ] Bug fix
- [x] Documentation
- [x] Breaking change 

I have:
- [x] Tested the code
- [x] Wrote unit tests for the code
- [x] Documented changes:
  - [x] Guide(s) 
  - [x] API reference
  - [x] Changelog

Changes:
- Members intent is by default disabled. A warning is issued if users don't enable it, since it is needed for invite tracking.
- Guilds intent get's enabled if it is not, a warning is issued if it was originally disabled. This is needed for basic functionality.
- Allow Selenium related objects to be sent over remote.
- [GUI] 'Load default' button when editing ``discord.Intents`` object