### PR TITLE
Persistent WebSocket connection (remote events)

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -69,6 +69,12 @@ v3.0.0
     the API call to happen asynchronously unless awaited with ``await`` keyword. This also makes DAF
     much more efficient.
 
+  - Remote:
+
+    - Persistent WebSocket connection for receiving events from the core server
+      (eg. :func:`~daf.logging.tracing.trace()` events).
+
+
 
 v2.10.4
 ======================

--- a/src/daf/events.py
+++ b/src/daf/events.py
@@ -173,7 +173,11 @@ class EventController:
         if GLOBAL.g_controller is self:
             future = asyncio.gather(
                 future,
-                *[controller.emit(event, *args, **kwargs) for controller in GLOBAL.non_global_controllers]
+                *[
+                    controller.emit(event, *args, **kwargs)
+                    for controller in GLOBAL.non_global_controllers
+                    if controller.running
+                ]
             )  # Create a new future, that can be awaited for all event controllers to process an event
 
         return future
@@ -207,6 +211,7 @@ class EventController:
 
         if self is not GLOBAL.g_controller:
             GLOBAL.non_global_controllers.remove(self)
+
         self.clear_queue()
 
 

--- a/src/daf/logging/tracing.py
+++ b/src/daf/logging/tracing.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from sys import _getframe
 
 from ..misc import doc
-
+from ..events import get_global_event_ctrl, EventID
 
 try:
     from enum_tools.documentation import document_enum
@@ -120,7 +120,6 @@ def trace(message: str,
         )
 
         with GLOBALS.lock:
-            from ..events import get_global_event_ctrl, EventID
             evt = get_global_event_ctrl()
             evt.emit(EventID.g_trace, level, message)
             print(TRACE_COLOR_MAP[level] + msg + "\033[0m")

--- a/src/daf/logging/tracing.py
+++ b/src/daf/logging/tracing.py
@@ -120,6 +120,9 @@ def trace(message: str,
         )
 
         with GLOBALS.lock:
+            from ..events import get_global_event_ctrl, EventID
+            evt = get_global_event_ctrl()
+            evt.emit(EventID.g_trace, level, message)
             print(TRACE_COLOR_MAP[level] + msg + "\033[0m")
 
 

--- a/src/daf/remote.py
+++ b/src/daf/remote.py
@@ -251,12 +251,14 @@ async def http_ws_live_connect(request: Request):
 
     ws = WebSocketResponse()
     await ws.prepare(request)
-    
+
     evt = get_global_event_ctrl()
     evt.add_listener(EventID.g_trace, trace_event_publisher)
+    evt.add_listener(EventID.g_daf_shutdown, ws.close)
     async for message in ws:
         if message.type == WSMsgType.CLOSE:
             await ws.close()
 
     evt.remove_listener(EventID.g_trace, trace_event_publisher)
+    evt.remove_listener(EventID.g_daf_shutdown, ws.close)
     return ws

--- a/src/daf_gui/connector.py
+++ b/src/daf_gui/connector.py
@@ -268,17 +268,13 @@ class RemoteConnectionCLIENT(AbstractConnectionCLIENT):
         await self._ws_task
 
     async def add_account(self, obj: daf.client.ACCOUNT):
-        trace("Logging in.")
         response = await self._request(
             "POST", "/accounts",
             account=daf.convert.convert_object_to_semi_dict(obj)
         )
-        trace(response["message"])
 
     async def remove_account(self, account_ref: it.ObjectReference):
-        trace("Removing remote account.")
         response = await self._request("DELETE", "/accounts", account_id=account_ref.ref)
-        trace(response["message"])
 
     async def get_accounts(self) -> List[daf.client.ACCOUNT]:
         response = await self._request("GET", "/accounts")
@@ -295,8 +291,6 @@ class RemoteConnectionCLIENT(AbstractConnectionCLIENT):
     async def execute_method(self, object_ref: it.ObjectReference, method_name: str, **kwargs):
         kwargs = daf.convert.convert_object_to_semi_dict(kwargs)
         response = await self._request("POST", "/method", object_id=object_ref.ref, method_name=method_name, **kwargs)
-        message = response.get("message")
-        trace(message, TraceLEVELS.NORMAL)
         return daf.convert.convert_from_semi_dict(response["result"]["result"])
 
     def _ping(self):

--- a/src/daf_gui/connector.py
+++ b/src/daf_gui/connector.py
@@ -241,13 +241,13 @@ class RemoteConnectionCLIENT(AbstractConnectionCLIENT):
         while self.connected:
             trace("Connecting to live WebSocket connection.")
             try:
-                async with self.session.ws_connect("/subscribe") as ws:
+                async with self.session.ws_connect("/subscribe", auth=self.auth) as ws:
                     trace("Connected to WebSocket.")
                     async for message in ws:
                         if message.type == WSMsgType.TEXT:
                             resp = daf.convert_from_semi_dict(message.json())
                             type = resp["type"]
-                            data = resp["data"]
+                            data = resp.get("data")
                             if type == "trace":
                                 trace(data["message"], data["level"])
 
@@ -258,7 +258,7 @@ class RemoteConnectionCLIENT(AbstractConnectionCLIENT):
                         elif message.type == WSMsgType.ERROR:
                             raise ws.exception()
             except Exception as exc:
-                trace(f"WebSocket error received: {ws.exception()}")
+                trace(f"WebSocket error received: {exc}", TraceLEVELS.ERROR)
 
         trace("Websocket connection closed", TraceLEVELS.DEBUG)
 

--- a/src/daf_gui/connector.py
+++ b/src/daf_gui/connector.py
@@ -239,9 +239,10 @@ class RemoteConnectionCLIENT(AbstractConnectionCLIENT):
 
     async def _connect_ws(self):
         while self.connected:
-            trace("Connecting to live WebSocket connection.", TraceLEVELS.NORMAL)
+            trace("Connecting to live WebSocket connection.")
             try:
                 async with self.session.ws_connect("/subscribe") as ws:
+                    trace("Connected to WebSocket.")
                     async for message in ws:
                         if message.type == WSMsgType.TEXT:
                             resp = daf.convert_from_semi_dict(message.json())


### PR DESCRIPTION
Pull request type:
- [x] Feature
- [ ] Bug fix
- [x] Documentation
- [ ] Breaking change 

I have:
- [x] Tested the code
- [ ] Wrote unit tests for the code
- [x] Documented changes:
  - [ ] Guide(s)
  - [x] API reference
  - [x] Changelog

Changes:
- Created a persistent WebSocket connection for forwarding global events emitted on the server to a remote GUI. This is mostly used for forwarding traces (prints) out from the server to the GUI.
