### PR TITLE
Refactored the way ``AutoGUILD`` works

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -37,6 +37,14 @@ Glossary
 Releases
 ---------------------
 
+v3.3.0
+===================
+- Changed how :class:`daf.guild.AutoGUILD` works. It will now create :class:`daf.guild.GUILD` instances.
+  This also prevents a "bug" that appeared if the user was timed-out in a guild, which reflected upon other
+  guilds as well. The added benefit of creating :class:`~daf.guild.GUILD` is different randomized sending
+  periods across multiple guilds (assuming randomized sending period was configured).
+
+
 v3.2.0
 ===================
 - GUI:

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -39,7 +39,7 @@ Releases
 
 v3.3.0
 ===================
-- Changed how :class:`daf.guild.AutoGUILD` works. It will now create :class:`daf.guild.GUILD` instances.
+- |POTENT_BREAK_CH| Changed how :class:`daf.guild.AutoGUILD` works. It will now create :class:`daf.guild.GUILD` instances.
   This also prevents a "bug" that appeared if the user was timed-out in a guild, which reflected upon other
   guilds as well. The added benefit of creating :class:`~daf.guild.GUILD` is different randomized sending
   periods across multiple guilds (assuming randomized sending period was configured).

--- a/src/daf/__init__.py
+++ b/src/daf/__init__.py
@@ -20,7 +20,7 @@ import sys
 import warnings
 
 
-VERSION = "3.2.0"
+VERSION = "3.3.0"
 
 if sys.version_info.minor == 12 and sys.version_info.major == 3:
     warnings.warn(

--- a/src/daf/client.py
+++ b/src/daf/client.py
@@ -436,7 +436,7 @@ class ACCOUNT:
         self._running = True
         async with self._event_ctrl.critical():
             for server in self._servers:
-                if (await server.initialize(self, self._event_ctrl)) is not None:
+                if (exc := await server.initialize(self, self._event_ctrl)) is not None:
                     await self._on_remove_server(server)
 
 

--- a/src/daf/convert.py
+++ b/src/daf/convert.py
@@ -367,7 +367,7 @@ def convert_object_to_semi_dict(to_convert: Any, only_ref: bool = False) -> Mapp
     if only_ref:
         # Don't serialize object completly, only ID is requested.
         # This prevents unnecessarily large data to be encoded
-        to_convert = ObjectReference(get_object_id(to_convert))
+        to_convert = ObjectReference.from_object(to_convert)
 
     return _convert_json_slots(to_convert)
 

--- a/src/daf/dtypes.py
+++ b/src/daf/dtypes.py
@@ -5,11 +5,13 @@
 from typing import Any, Callable, Coroutine, Union, Optional
 from os.path import basename
 from typeguard import typechecked
-import importlib.util as iu
-import io
+from functools import wraps
 
 from .logging.tracing import *
 from .misc import doc
+
+import importlib.util as iu
+import io
 
 
 __all__ = (
@@ -80,7 +82,7 @@ def data_function(fnc: Callable):
         :language: python
         :emphasize-lines: 12, 24
     """
-
+    @wraps(fnc, updated=[])
     class FunctionCLASS(_FunctionBaseCLASS):
         """
         Used for creating special classes that are then used to create objects in the daf.MESSAGE

--- a/src/daf/events.py
+++ b/src/daf/events.py
@@ -63,6 +63,8 @@ class EventID(Enum):
 
     discord_member_join = auto()
     discord_invite_delete = auto()
+    discord_guild_join = auto()
+    discord_guild_remove = auto()
 
     _dummy = auto()  # For stopping the event loop
 

--- a/src/daf/guild/autoguild.py
+++ b/src/daf/guild/autoguild.py
@@ -180,7 +180,7 @@ class AutoGUILD:
 
         Parameters
         --------------
-        message: BaseMESSAGE
+        message: BaseChannelMessage
             Message object to add.
 
         Returns
@@ -202,8 +202,25 @@ class AutoGUILD:
     
 
     @typechecked
-    def remove_message(self, message: BaseChannelMessage):
+    def remove_message(self, message: BaseChannelMessage) -> asyncio.Future:
+        """
+        Remove a ``message`` from the advertising list.
+
+        |ASYNC_API|
+
+        Parameters
+        --------------
+        message: BaseChannelMessage
+            Message object to remove.
+
+        Returns
+        --------
+        Awaitable
+            An awaitable object which can be used to await for execution to finish.
+            To wait for the execution to finish, use ``await`` like so: ``await method_name()``.
+        """
         self._messages.remove(message)
+        futures = []
         for g in self._gen_guilds:
             # Get the copied message index, all deep copied messages compare True, if they
             # were copied from the same source message.
@@ -211,7 +228,9 @@ class AutoGUILD:
             if idx == -1:
                 continue
 
-            g.remove_message(g._messages[idx])
+            futures.append(g.remove_message(g._messages[idx]))
+
+        return asyncio.gather(*futures)
 
     def update(self, init_options = None, **kwargs) -> asyncio.Future:
         """

--- a/src/daf/guild/guilduser.py
+++ b/src/daf/guild/guilduser.py
@@ -274,7 +274,7 @@ class BaseGUILD:
 
         if _apiobject is None:
             trace(f"Invalid ID {self.snowflake} - {self}", TraceLEVELS.ERROR, exception_cls=ValueError)
-        
+
         self._apiobject = _apiobject
         if self._remove_after is not None:
             if isinstance(self._remove_after, timedelta):

--- a/src/daf/misc/instance_track.py
+++ b/src/daf/misc/instance_track.py
@@ -48,8 +48,6 @@ class ObjectReference:
         return cls(get_object_id(obj), obj._tracked_allow_remote)
 
 
-
-
 def track_id(cls):
     """
     Decorator which replaces the __new__ method with a function that keeps a weak reference.

--- a/src/daf/misc/instance_track.py
+++ b/src/daf/misc/instance_track.py
@@ -27,8 +27,8 @@ def get_by_id(id_: int):
 
 
 def get_object_id(obj: object) -> int:
-    "Returns either internal daf's ID if it exist otherwise just the regular id()"
-    return getattr(obj, "_daf_id", -1)
+    "Returns either internal daf's ID"
+    return getattr(obj, "_daf_id")
 
 
 class ObjectReference:
@@ -36,8 +36,18 @@ class ObjectReference:
     Descriptive class that describes a reference to an object
     instead of the object itself. Useful for reducing unneeded storage.
     """
-    def __init__(self, ref: int) -> None:
+    def __init__(self, ref: int, remote_allowed = True) -> None:
         self.ref = ref
+        self.remote_allowed = remote_allowed  # Can be transferred, but not manipulated
+
+    @classmethod
+    def from_object(cls, obj: object):
+        if not hasattr(obj, "_daf_id") or obj._daf_id == -1:
+            return None
+
+        return cls(get_object_id(obj), obj._tracked_allow_remote)
+
+
 
 
 def track_id(cls):
@@ -47,10 +57,20 @@ def track_id(cls):
     @wraps(cls, updated=[])
     class TrackedClass(cls):
         if hasattr(cls, "__slots__"):  # Don't break classes without slots
-            __slots__ = ("__weakref__", "_daf_id")
+            __slots__ = ("__weakref__", "_daf_id", "_tracked_allow_remote")
 
-        def _update_tracked_id(self):
-            "Saves ID to the tracked dictionary"
+        def _update_tracked_id(self, allow_remote: bool = True):
+            """
+            Saves ID to the tracked dictionary
+
+            Parameters
+            --------------
+            allow_remote: bool
+                Should a remote client be able to manipulate the object.
+                If this is False, the object will be tracked but refresh,
+                update and method execution will not be available.
+            """
+            self._tracked_allow_remote = allow_remote
             value = id(self)
             self._daf_id = value
             OBJECT_ID_MAP[value] = self

--- a/src/daf/remote.py
+++ b/src/daf/remote.py
@@ -230,7 +230,7 @@ async def http_execute_method(object_id: int, method_name: str, **kwargs):
     """
     object = it.get_by_id(object_id)
     try:
-        if not object.remote_allowed:  # Can't type check attribute because it's part of a wrapper class.
+        if not object._tracked_allow_remote:  # Can't type check attribute because it's part of a wrapper class.
             raise TypeError(f"Method execution not available on {object.__name__}")
 
         result = getattr(object, method_name)(**convert.convert_from_semi_dict(kwargs))

--- a/src/daf/remote.py
+++ b/src/daf/remote.py
@@ -230,6 +230,9 @@ async def http_execute_method(object_id: int, method_name: str, **kwargs):
     """
     object = it.get_by_id(object_id)
     try:
+        if not object.remote_allowed:  # Can't type check attribute because it's part of a wrapper class.
+            raise TypeError(f"Method execution not available on {object.__name__}")
+
         result = getattr(object, method_name)(**convert.convert_from_semi_dict(kwargs))
         if isinstance(result, Awaitable):
             result = await result

--- a/src/daf_gui/main.py
+++ b/src/daf_gui/main.py
@@ -490,7 +490,7 @@ class Application():
                 param_object = combo_history.combo.get()
                 param_object_params = convert_to_objects(param_object.data)
                 items = await self.connection.execute_method(
-                    it.ObjectReference(it.get_object_id(logger)), getter_history, **param_object_params
+                    it.ObjectReference.from_object(logger), getter_history, **param_object_params
                 )
                 items = convert_to_object_info(items)
                 lst_history.clear()
@@ -513,7 +513,7 @@ class Application():
             async def delete_logs_async(primary_keys: List[int]):
                 logger = await self.connection.get_logger()
                 await self.connection.execute_method(
-                    it.ObjectReference(it.get_object_id(logger)),
+                    it.ObjectReference.from_object(logger),
                     "delete_logs",
                     primary_keys=primary_keys  # TODO: update on server
                 )
@@ -574,7 +574,11 @@ class Application():
                 logger = await self.connection.get_logger()
                 param_object = combo_count.combo.get()
                 parameters = convert_to_objects(param_object.data)
-                count = await self.connection.execute_method(it.ObjectReference(it.get_object_id(logger)), getter_counts, **parameters)
+                count = await self.connection.execute_method(
+                    it.ObjectReference.from_object(logger),
+                    getter_counts,
+                    **parameters
+                )
 
                 tw_num.delete_rows()
                 tw_num.insert_rows(0, count)

--- a/src/daf_gui/tod_extensions/convert.py
+++ b/src/daf_gui/tod_extensions/convert.py
@@ -12,8 +12,8 @@ from daf.logging.tracing import *
 
 
 def load_extension_to_object_info(object_, ret: ObjectInfo, *, save_original = False):    
-    if save_original and isinstance(ret, ObjectInfo) and (id_ := get_object_id(object_)) != -1:
-        ret.real_object = ObjectReference(id_)
+    if save_original and isinstance(ret, ObjectInfo):
+        ret.real_object = ObjectReference.from_object(object_)
 
         # Convert object properties
         # This will only be aviable for live objects, since it has no configuration value,

--- a/src/daf_gui/tod_extensions/convert.py
+++ b/src/daf_gui/tod_extensions/convert.py
@@ -11,9 +11,9 @@ from daf.logging.tracing import *
 
 
 
-def load_extension_to_object_info(object_, ret: ObjectInfo, *, save_original = False):
-    if save_original and isinstance(ret, ObjectInfo):
-        ret.real_object = ObjectReference(get_object_id(object_))
+def load_extension_to_object_info(object_, ret: ObjectInfo, *, save_original = False):    
+    if save_original and isinstance(ret, ObjectInfo) and (id_ := get_object_id(object_)) != -1:
+        ret.real_object = ObjectReference(id_)
 
         # Convert object properties
         # This will only be aviable for live objects, since it has no configuration value,

--- a/src/daf_gui/tod_extensions/extra_widgets.py
+++ b/src/daf_gui/tod_extensions/extra_widgets.py
@@ -96,7 +96,7 @@ def setup_additional_live_update(w: ttk.Button, frame):
         not frame.allow_save or
         (oi := frame.old_gui_data) is None or
         oi.real_object is None or
-        oi.real_object.ref == -1
+        not oi.real_object.remote_allowed
     ):
         return
 
@@ -125,7 +125,7 @@ def setup_additional_live_refresh(w: ttk.Button, frame):
     if (
         (oi := frame.old_gui_data) is None or
         oi.real_object is None or
-        oi.real_object.ref == -1
+        not oi.real_object.remote_allowed
     ):
         return
 
@@ -155,8 +155,8 @@ def setup_additional_live_properties(w: ttk.Menubutton, frame):
     if (
         (oi := frame.old_gui_data) is None or
         oi.real_object is None or
-        oi.real_object.ref == -1 or
-        not oi.property_map # Empty dict
+        not oi.real_object.remote_allowed or
+        not oi.property_map  # No properties
     ):
         return
 

--- a/src/daf_gui/tod_extensions/method_execution.py
+++ b/src/daf_gui/tod_extensions/method_execution.py
@@ -16,7 +16,7 @@ import daf
 EXECUTABLE_METHODS = {
     daf.guild.GUILD: [daf.guild.GUILD.add_message, daf.guild.GUILD.remove_message],
     daf.guild.USER: [daf.guild.USER.add_message, daf.guild.USER.remove_message],
-    daf.guild.AutoGUILD: [daf.guild.AutoGUILD.add_message, daf.guild.AutoGUILD.remove_message],
+    daf.guild.AutoGUILD: [daf.guild.AutoGUILD.add_message],
     daf.client.ACCOUNT: [daf.client.ACCOUNT.add_server, daf.client.ACCOUNT.remove_server]
 }
 ADDITIONAL_PARAMETER_VALUES = {
@@ -25,10 +25,6 @@ ADDITIONAL_PARAMETER_VALUES = {
         "message": lambda old_info: old_info.data["messages"]
     },
     daf.USER.remove_message: {
-        # GUILD.messages
-        "message": lambda old_info: old_info.data["messages"]
-    },
-    daf.AutoGUILD.remove_message: {
         # GUILD.messages
         "message": lambda old_info: old_info.data["messages"]
     },

--- a/src/daf_gui/tod_extensions/method_execution.py
+++ b/src/daf_gui/tod_extensions/method_execution.py
@@ -16,7 +16,7 @@ import daf
 EXECUTABLE_METHODS = {
     daf.guild.GUILD: [daf.guild.GUILD.add_message, daf.guild.GUILD.remove_message],
     daf.guild.USER: [daf.guild.USER.add_message, daf.guild.USER.remove_message],
-    daf.guild.AutoGUILD: [daf.guild.AutoGUILD.add_message],
+    daf.guild.AutoGUILD: [daf.guild.AutoGUILD.add_message, daf.guild.AutoGUILD.remove_message],
     daf.client.ACCOUNT: [daf.client.ACCOUNT.add_server, daf.client.ACCOUNT.remove_server]
 }
 ADDITIONAL_PARAMETER_VALUES = {
@@ -26,6 +26,10 @@ ADDITIONAL_PARAMETER_VALUES = {
     },
     daf.USER.remove_message: {
         # GUILD.messages
+        "message": lambda old_info: old_info.data["messages"]
+    },
+    daf.AutoGUILD.remove_message: {
+        # AutoGUILD.messages
         "message": lambda old_info: old_info.data["messages"]
     },
     daf.ACCOUNT.remove_server: {
@@ -40,6 +44,7 @@ def load_extension(frame: NewObjectFrameStruct, *args, **kwargs):
         frame.old_gui_data is None or
         # getattr since class_ can also be non ObjectInfo
         getattr(frame.old_gui_data, "real_object", None) is None or
+        not frame.old_gui_data.real_object.remote_allowed or
         (available_methods := EXECUTABLE_METHODS.get(frame.class_)) is None or
         not frame.allow_save
     ):

--- a/testing/test_remote.py
+++ b/testing/test_remote.py
@@ -22,27 +22,27 @@ async def test_http(accounts, guilds):
 
     # Execute method
     await client.execute_method(
-        it.ObjectReference(it.get_object_id(accounts[0])),
+        it.ObjectReference.from_object(accounts[0]),
         "add_server",
         server=daf.GUILD(guilds[0].id)
     )
-    new_object = await client.refresh(it.ObjectReference(it.get_object_id(accounts[0])))
+    new_object = await client.refresh(it.ObjectReference.from_object(accounts[0]))
     assert len(new_object.servers) == 1
 
     await client.execute_method(
-        it.ObjectReference(it.get_object_id(new_object)),
+        it.ObjectReference.from_object(new_object),
         "remove_server",
-        server=it.ObjectReference(it.get_object_id(new_object.servers[0]))
+        server=it.ObjectReference.from_object(new_object.servers[0])
     )
-    new_object = await client.refresh(it.ObjectReference(it.get_object_id(accounts[0])))
+    new_object = await client.refresh(it.ObjectReference.from_object(accounts[0]))
     assert len(new_object.servers) == 0
 
     # Test object retrieval
-    new_object = await client.refresh(it.ObjectReference(it.get_object_id(accounts[0])))
+    new_object = await client.refresh(it.ObjectReference.from_object(accounts[0]))
     assert new_object._daf_id == accounts[0]._daf_id
     # Test account removal
-    await client.remove_account(it.ObjectReference(it.get_object_id(accounts[0])))
-    await client.remove_account(it.ObjectReference(it.get_object_id(accounts[1])))
+    await client.remove_account(it.ObjectReference.from_object(accounts[0]))
+    await client.remove_account(it.ObjectReference.from_object(accounts[1]))
     # Test account addition
     await client.add_account(accounts[0])
     await client.add_account(accounts[1])


### PR DESCRIPTION
Pull request type:
- [x] Feature
- [x] Bug fix
- [x] Documentation
- [x] Breaking change 

I have:
- [x] Tested the code
- [x] Wrote unit tests for the code
- [x] Documented changes:
  - [x] Guide(s)
  - [x] API reference
  - [x] Changelog

Changes:
- ``AutoGUILD`` will now generate ``GUILD`` objects, to avoid a single ratelimit / timeout from affecting all the GUILDs.
   This also adds a benefit of randomized sending periods across multiple guilds found by ``AutoGUILD``.

Possible to-do:
- Find a way to allow messages to be directly updated, without updating the entire``AutoGUILD``.
